### PR TITLE
Add PackAsTool property to csproj file

### DIFF
--- a/src/Aspirate.Cli/Aspirate.Cli.csproj
+++ b/src/Aspirate.Cli/Aspirate.Cli.csproj
@@ -4,6 +4,7 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net8.0</TargetFramework>
     <AssemblyName>Aspirate</AssemblyName>
+    <PackAsTool>true</PackAsTool>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Fix #20 

This pull request adds the PackAsTool property to the csproj file, allowing the project to be packed as a tool.

This was preventing me from using dotnet tool install on Windows as the package type was missing.