### PR TITLE
Remove copypastas, use known emoji from spectre

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,34 @@
 # Aspirate (Aspir8)
-## Convert Aspire Configuration file to Kustomize Manifests for K8s.
+### Convert Aspire Configuration file to Kustomize Manifests for K8s.
 
 Test with:
 ```bash
 dotnet run -- e2e -p ./Example/AppHost -o ./output
-cd ./output
-kustomize build .
 ```
+
+---
+
+### Configuring the Windows Terminal For Unicode and Emoji Support
+
+Windows Terminal supports Unicode and Emoji. However, the shells such as Powershell and cmd.exe do not.
+For the difference between the two,
+see [What's the difference between a console,
+a terminal and a shell](https://www.hanselman.com/blog/whats-the-difference-between-a-console-a-terminal-and-a-shell).
+
+For PowerShell, the following command will enable Unicode and Emoji support. You can add this to your `profile.ps1`
+file:
+
+```powershell
+[console]::InputEncoding = [console]::OutputEncoding = [System.Text.UTF8Encoding]::new()
+```
+
+For cmd.exe, the following steps are required to enable Unicode and Emoji support.
+
+1. Run `intl.cpl`.
+2. Click the Administrative tab
+3. Click the Change system locale button.
+4. Check the "Use Unicode UTF-8 for worldwide language support" checkbox.
+5. Reboot.
+
+You will also need to ensure that your Console application is configured to use a font that supports Unicode and Emoji,
+such as Cascadia Code.

--- a/src/Aspirate.Cli/Commands/EndToEnd/EndToEndCommand.cs
+++ b/src/Aspirate.Cli/Commands/EndToEnd/EndToEndCommand.cs
@@ -53,7 +53,7 @@ public class EndToEndCommand(IServiceProvider serviceProvider) : AsyncCommand<En
 
     private static async Task LogCreatedManifestAtPath(string resultFullPath)
     {
-        AnsiConsole.MarkupLine($"\t[green](✔) Done: [/] Created Aspire Manifest At Path: [blue]{resultFullPath}[/]");
+        AnsiConsole.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Created Aspire Manifest At Path: [blue]{resultFullPath}[/]");
         await Task.Delay(2000);
         Console.Clear();
     }
@@ -144,13 +144,6 @@ public class EndToEndCommand(IServiceProvider serviceProvider) : AsyncCommand<En
     private static void LogUnsupportedType(string resourceName) =>
         AnsiConsole.MarkupLine($"[yellow]Skipping resource '{resourceName}' as its type is unsupported.[/]");
 
-    private static Task LogGenerationComplete()
-    {
-        AnsiConsole.MarkupLine("\r\n[bold slowblink]Generation completed.[/]");
-
-        return Task.Delay(2000);
-    }
-
     private static Task LogContainerCompositionCompleted()
     {
         AnsiConsole.MarkupLine("\r\n[bold slowblink]Generation completed.[/]");
@@ -159,7 +152,7 @@ public class EndToEndCommand(IServiceProvider serviceProvider) : AsyncCommand<En
     }
 
     private static void LogCommandCompleted() =>
-        AnsiConsole.MarkupLine("\r\n[bold slowblink] 🚀 Execution Completed - Happy Deployment 😃[/]");
+        AnsiConsole.MarkupLine($"\r\n[bold] {EmojiLiterals.Rocket} Execution Completed - Happy Deployment {EmojiLiterals.Smiley}[/]");
 
     private static List<string> SelectManifestItemsToProcess(IEnumerable<string> manifestItems) =>
         AnsiConsole.Prompt(

--- a/src/Aspirate.Cli/Processors/Components/Project/ProjectProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Project/ProjectProcessor.cs
@@ -58,7 +58,7 @@ public class ProjectProcessor(
 
         var result = await containerCompositionService.BuildAndPushContainerForProject(project);
 
-        AnsiConsole.MarkupLine($"\t[green](✔) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
+        AnsiConsole.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
 
         return result;
     }

--- a/src/Aspirate.Contracts/Literals/EmojiLiterals.cs
+++ b/src/Aspirate.Contracts/Literals/EmojiLiterals.cs
@@ -1,0 +1,8 @@
+namespace Aspirate.Contracts.Literals;
+
+public static class EmojiLiterals
+{
+    public const string CheckMark = Emoji.Known.CheckMark;
+    public const string Smiley = Emoji.Known.SmilingFace;
+    public const string Rocket = Emoji.Known.Rocket;
+}

--- a/src/Aspirate.Contracts/Processors/BaseProcessor.cs
+++ b/src/Aspirate.Contracts/Processors/BaseProcessor.cs
@@ -93,5 +93,5 @@ public abstract class BaseProcessor<TTemplateData> : IProcessor where TTemplateD
     }
 
     protected static void LogCompletion(string outputPath) =>
-        AnsiConsole.MarkupLine($"\t[green](✔) Done: [/] Generating [blue]{outputPath}[/]");
+        AnsiConsole.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Generating [blue]{outputPath}[/]");
 }


### PR DESCRIPTION
Also add sttement to README about powershell and cmd, we don't want to really override the encoding of the users console from our application.
