### PR TITLE
Add init command

### DIFF
--- a/src/Aspirate.Cli/Commands/EndToEnd/EndToEndLogExtensions.cs
+++ b/src/Aspirate.Cli/Commands/EndToEnd/EndToEndLogExtensions.cs
@@ -41,6 +41,9 @@ public static class EndToEndLogExtensions
     public static void LogCommandCompleted(this IAnsiConsole console) =>
         console.MarkupLine($"\r\n[bold] {EmojiLiterals.Rocket} Execution Completed - Happy Deployment {EmojiLiterals.Smiley}[/]");
 
+    public static void LogLoadedConfigurationFile(this IAnsiConsole console, string pathToFile) =>
+        console.MarkupLine($"\r\n[bold] Successfully loaded existing aspirate bootstrap settings from [blue]'{pathToFile}'[/].[/]");
+
     public static void LogFailedToGenerateAspireManifest(this IAnsiConsole console, string path) =>
         console.MarkupLine($"[red]Failed to generate Aspire Manifest at: {path}[/]");
 }

--- a/src/Aspirate.Cli/Commands/Init/InitCommand.cs
+++ b/src/Aspirate.Cli/Commands/Init/InitCommand.cs
@@ -1,0 +1,80 @@
+namespace Aspirate.Cli.Commands.Init;
+
+public sealed class InitCommand(
+    IAnsiConsole console,
+    IAspirateConfigurationService aspirateConfigurationService,
+    IServiceProvider serviceProvider) : AsyncCommand<InitInput>
+{
+    public const string InitCommandName = "init";
+    public const string InitDescription = "Initializes aspirate settings within your AppHost directory.";
+
+    public override Task<int> ExecuteAsync(CommandContext context, InitInput settings)
+    {
+        aspirateConfigurationService.HandleExistingConfiguration(settings.PathToAspireProjectFlag);
+
+        var aspirateSettings = PerformConfigurationBootstrapping();
+
+        aspirateConfigurationService.SaveConfigurationFile(aspirateSettings, settings.PathToAspireProjectFlag);
+
+        console.LogCommandCompleted();
+
+        return Task.FromResult(0);
+    }
+
+    private AspirateSettings PerformConfigurationBootstrapping()
+    {
+        var aspirateConfiguration = new AspirateSettings();
+
+        HandleContainerRegistry(aspirateConfiguration);
+
+        HandleContainerTag(aspirateConfiguration);
+
+        HandleTemplateDirectory(aspirateConfiguration);
+
+        return aspirateConfiguration;
+    }
+
+    private void HandleContainerRegistry(AspirateSettings aspirateConfiguration)
+    {
+        console.MarkupLine("\r\nAspirate supports setting a fall-back value for projects that have not yet set a [blue]'ContainerRegistry'[/] in their csproj file.");
+        var shouldSetContainerRegistry = console.Confirm("Would you like to set a fall-back value for the container registry?", false);
+
+        if (!shouldSetContainerRegistry)
+        {
+            return;
+        }
+
+        var containerRegistry = console.Prompt(new TextPrompt<string>("\tPlease enter the container registry to use as a fall-back value:").PromptStyle("blue"));
+        aspirateConfiguration.ContainerSettings.Registry = containerRegistry;
+    }
+
+    private void HandleContainerTag(AspirateSettings aspirateConfiguration)
+    {
+        console.MarkupLine("\r\nAspirate supports setting a fall-back value for projects that have not yet set a [blue]'ContainerTag'[/] in their csproj file.");
+        var shouldSetContainerTag = console.Confirm("Would you like to set a fall-back value for the container tag?", false);
+
+        if (!shouldSetContainerTag)
+        {
+            return;
+        }
+
+        var containerTag = console.Prompt(new TextPrompt<string>("\tPlease enter the container tag to use as a fall-back value:").PromptStyle("blue"));
+        aspirateConfiguration.ContainerSettings.Tag = containerTag;
+        console.WriteLine();
+    }
+
+    private void HandleTemplateDirectory(AspirateSettings aspirateConfiguration)
+    {
+        console.MarkupLine("\r\nAspirate supports setting a custom directory for [blue]'Templates'[/] that are used when generating kustomize manifests.");
+        var shouldSetCustomTemplateDirectory = console.Confirm("Would you like to use a custom directory (selecting [green]'n'[/] will default to built in templates ?", false);
+
+        if (!shouldSetCustomTemplateDirectory)
+        {
+            return;
+        }
+
+        var templatePath = console.Prompt(new TextPrompt<string>("\tPlease enter the path to use as the template directory:").PromptStyle("blue"));
+        aspirateConfiguration.TemplatePath = templatePath;
+        console.WriteLine();
+    }
+}

--- a/src/Aspirate.Cli/Commands/Init/InitInput.cs
+++ b/src/Aspirate.Cli/Commands/Init/InitInput.cs
@@ -1,0 +1,14 @@
+namespace Aspirate.Cli.Commands.Init;
+
+/// <summary>
+/// The input for the EndToEndCommand
+/// </summary>
+public sealed class InitInput : CommandSettings
+{
+    /// <summary>
+    /// The path to the Aspire manifest
+    /// </summary>
+    [CommandOption("-p|--project")]
+    [Description("The path to the Aspire AppHost project")]
+    public required string PathToAspireProjectFlag { get; init; }
+}

--- a/src/Aspirate.Cli/Commands/Init/InitLogExtensions.cs
+++ b/src/Aspirate.Cli/Commands/Init/InitLogExtensions.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Cli.Commands.Init;
+
+public static class InitLogExtensions
+{
+    public static void LogCommandCompleted(this IAnsiConsole console) =>
+        console.MarkupLine($"\r\n[bold] {EmojiLiterals.Rocket} Execution Completed[/]");
+}

--- a/src/Aspirate.Cli/Extensions/PathExtensions.cs
+++ b/src/Aspirate.Cli/Extensions/PathExtensions.cs
@@ -1,0 +1,18 @@
+namespace Aspirate.Cli.Extensions;
+
+public static class PathExtensions
+{
+    public static string NormalizePath(this IFileSystem fileSystem, string pathToTarget)
+    {
+        if (!pathToTarget.StartsWith('.'))
+        {
+            return pathToTarget;
+        }
+
+        var currentDirectory = fileSystem.Directory.GetCurrentDirectory();
+
+        var normalizedProjectPath = pathToTarget.Replace('\\', fileSystem.Path.DirectorySeparatorChar);
+
+        return fileSystem.Path.Combine(currentDirectory, normalizedProjectPath);
+    }
+}

--- a/src/Aspirate.Cli/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Cli/Extensions/ServiceCollectionExtensions.cs
@@ -5,17 +5,22 @@ internal static class ServiceCollectionExtensions
         services
             .AddSpectreConsole()
             .AddAspireManifestSupport()
+            .AddAspirateConfigurationSupport()
             .AddContainerSupport()
             .AddProcessors();
 
     private static IServiceCollection AddSpectreConsole(this IServiceCollection services) =>
-        services.AddSingleton<IAnsiConsole>(AnsiConsole.Console);
+        services.AddSingleton(AnsiConsole.Console);
 
     private static IServiceCollection AddAspireManifestSupport(this IServiceCollection services) =>
         services
             .AddSingleton<IFileSystem, FileSystem>()
             .AddSingleton<IAspireManifestCompositionService, AspireManifestCompositionService>()
             .AddSingleton<IManifestFileParserService, ManifestFileParserService>();
+
+    private static IServiceCollection AddAspirateConfigurationSupport(this IServiceCollection services) =>
+        services
+            .AddSingleton<IAspirateConfigurationService, AspirateConfigurationService>();
 
     private static IServiceCollection AddContainerSupport(this IServiceCollection services) =>
         services

--- a/src/Aspirate.Cli/GlobalUsings.cs
+++ b/src/Aspirate.Cli/GlobalUsings.cs
@@ -5,6 +5,7 @@ global using System.ComponentModel;
 global using System.Text;
 global using System.Text.Json;
 global using Aspirate.Cli.Commands.EndToEnd;
+global using Aspirate.Cli.Commands.Init;
 global using Microsoft.Extensions.DependencyInjection;
 
 global using Aspirate.Cli.Extensions;
@@ -17,6 +18,7 @@ global using Aspirate.Cli.Services;
 global using Aspirate.Contracts.Interfaces;
 global using Aspirate.Contracts.Literals;
 global using Aspirate.Contracts.Models;
+global using Aspirate.Contracts.Models.Aspirate;
 global using Aspirate.Contracts.Models.AspireManifests;
 global using Aspirate.Contracts.Models.AspireManifests.Components;
 global using Aspirate.Contracts.Models.AspireManifests.Components.V0;

--- a/src/Aspirate.Cli/Processors/Components/Final/FinalProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Final/FinalProcessor.cs
@@ -13,12 +13,12 @@ public class FinalProcessor(IFileSystem fileSystem, IAnsiConsole console) : Base
     public override Resource Deserialize(ref Utf8JsonReader reader) =>
         throw new NotImplementedException();
 
-    public void CreateFinalManifest(Dictionary<string, Resource> resources, string outputPath)
+    public void CreateFinalManifest(Dictionary<string, Resource> resources, string outputPath, AspirateSettings? aspirateSettings = null)
     {
         var manifests = resources.Select(x => x.Key).ToList();
 
         var templateData = new FinalTemplateData(manifests);
 
-        CreateComponentKustomizeManifest(outputPath, templateData);
+        CreateComponentKustomizeManifest(outputPath, templateData, aspirateSettings);
     }
 }

--- a/src/Aspirate.Cli/Processors/Components/Postgresql/PostgresDatabaseProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Postgresql/PostgresDatabaseProcessor.cs
@@ -13,7 +13,7 @@ public class PostgresDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole cons
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<PostgresDatabase>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath) =>
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null) =>
         // Do nothing for databases, they are there for configuration.
         Task.FromResult(true);
 }

--- a/src/Aspirate.Cli/Processors/Components/Postgresql/PostgresServerProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Postgresql/PostgresServerProcessor.cs
@@ -17,7 +17,7 @@ public class PostgresServerProcessor(IFileSystem fileSystem, IAnsiConsole consol
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<PostgresServer>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 
@@ -25,8 +25,8 @@ public class PostgresServerProcessor(IFileSystem fileSystem, IAnsiConsole consol
 
         var data = new PostgresServerTemplateData(_manifests);
 
-        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.PostgresServerType}.yml", TemplateLiterals.PostgresServerType, data);
-        CreateComponentKustomizeManifest(resourceOutputPath, data);
+        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.PostgresServerType}.yml", TemplateLiterals.PostgresServerType, data, aspirateSettings);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, aspirateSettings);
 
         LogCompletion(resourceOutputPath);
 

--- a/src/Aspirate.Cli/Processors/Components/Project/ProjectProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Project/ProjectProcessor.cs
@@ -27,7 +27,7 @@ public class ProjectProcessor(
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<AspireProject>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 
@@ -46,9 +46,9 @@ public class ProjectProcessor(
             project.Env,
             _manifests);
 
-        CreateDeployment(resourceOutputPath, data);
-        CreateService(resourceOutputPath, data);
-        CreateComponentKustomizeManifest(resourceOutputPath, data);
+        CreateDeployment(resourceOutputPath, data, aspirateSettings);
+        CreateService(resourceOutputPath, data, aspirateSettings);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, aspirateSettings);
 
         LogCompletion(resourceOutputPath);
 
@@ -69,11 +69,13 @@ public class ProjectProcessor(
         _console.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
     }
 
-    public async Task PopulateContainerDetailsCacheForProject(KeyValuePair<string, Resource> resource)
+    public async Task PopulateContainerDetailsCacheForProject(
+        KeyValuePair<string, Resource> resource,
+        AspirateSettings? aspirateSettings)
     {
         var project = resource.Value as AspireProject;
 
-        var details = await containerDetailsService.GetContainerDetails(resource.Key, project);
+        var details = await containerDetailsService.GetContainerDetails(resource.Key, project, aspirateSettings);
 
         var success = _containerDetailsCache.TryAdd(resource.Key, details);
 

--- a/src/Aspirate.Cli/Processors/Components/RabbitMQ/RabbitMQProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/RabbitMQ/RabbitMQProcessor.cs
@@ -19,7 +19,7 @@ public class RabbitMqProcessor(IFileSystem fileSystem, IAnsiConsole console) : B
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<AspireRabbit>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 
@@ -27,8 +27,8 @@ public class RabbitMqProcessor(IFileSystem fileSystem, IAnsiConsole console) : B
 
         var data = new RabbitMqTemplateData(_manifests);
 
-        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.RabbitMqType}.yml", TemplateLiterals.RabbitMqType, data);
-        CreateComponentKustomizeManifest(resourceOutputPath, data);
+        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.RabbitMqType}.yml", TemplateLiterals.RabbitMqType, data, aspirateSettings);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, aspirateSettings);
 
         LogCompletion(resourceOutputPath);
 

--- a/src/Aspirate.Cli/Processors/Components/Redis/RedisProcessor.cs
+++ b/src/Aspirate.Cli/Processors/Components/Redis/RedisProcessor.cs
@@ -19,7 +19,7 @@ public class RedisProcessor(IFileSystem fileSystem, IAnsiConsole console) : Base
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<AspireRedis>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 
@@ -27,8 +27,8 @@ public class RedisProcessor(IFileSystem fileSystem, IAnsiConsole console) : Base
 
         var data = new RedisTemplateData(_manifests);
 
-        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.RedisType}.yml", TemplateLiterals.RedisType, data);
-        CreateComponentKustomizeManifest(resourceOutputPath, data);
+        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.RedisType}.yml", TemplateLiterals.RedisType, data, aspirateSettings);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, aspirateSettings);
 
         LogCompletion(resourceOutputPath);
 

--- a/src/Aspirate.Cli/Program.cs
+++ b/src/Aspirate.Cli/Program.cs
@@ -11,7 +11,11 @@ app.Configure(
         config.AddCommand<EndToEndCommand>(EndToEndCommand.EndToEndCommandName)
             .WithDescription(EndToEndCommand.EndToEndDescription)
             .WithAlias("e2e")
-            .WithExample(["e2e", "-m", "./Example/aspire-manifest.json", "-o", "./output"]);
+            .WithExample(["e2e", "-m", "./Example/AppHost", "-o", "./output"]);
+
+        config.AddCommand<InitCommand>(InitCommand.InitCommandName)
+            .WithDescription(InitCommand.InitDescription)
+            .WithExample(["init", "-m", "./Example/AppHost"]);
     });
 
 return app.Run(args);

--- a/src/Aspirate.Cli/Properties/launchSettings.json
+++ b/src/Aspirate.Cli/Properties/launchSettings.json
@@ -2,7 +2,13 @@
   "profiles": {
     "end-to-end": {
       "commandName": "Project",
-      "commandLineArgs": "e2e -p ./AppHost.csproj -o ./output",
+      "commandLineArgs": "e2e -p . -o ./output",
+      "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
+      "hotReloadEnabled": false
+    },
+    "init": {
+      "commandName": "Project",
+      "commandLineArgs": "init -p .",
       "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
       "hotReloadEnabled": false
     }

--- a/src/Aspirate.Cli/Services/AspirateConfigurationService.cs
+++ b/src/Aspirate.Cli/Services/AspirateConfigurationService.cs
@@ -1,0 +1,76 @@
+namespace Aspirate.Cli.Services;
+
+public class AspirateConfigurationService(IAnsiConsole console, IFileSystem fileSystem) : IAspirateConfigurationService
+{
+    private readonly JsonSerializerOptions _jsonSerializerOptions = new() { WriteIndented = true };
+
+    public void HandleExistingConfiguration(string appHostPath)
+    {
+        var configurationPath = fileSystem.NormalizePath(appHostPath);
+        var configurationFile = fileSystem.Path.Combine(configurationPath, AspirateSettings.FileName);
+
+        if (!fileSystem.File.Exists(configurationFile))
+        {
+            return;
+        }
+
+        LogExistingConfigurationFound();
+
+        var shouldDelete = console.Confirm("Would you like to overwrite the existing configuration?");
+
+        if (!shouldDelete)
+        {
+            LogExistingNotDeleted();
+            Environment.Exit(1);
+        }
+
+        File.Delete(configurationFile);
+        LogExistingConfigurationDeleted();
+    }
+
+    public AspirateSettings? LoadConfigurationFile(string appHostPath)
+    {
+        var configurationPath = fileSystem.NormalizePath(appHostPath);
+        var configurationFile = fileSystem.Path.Combine(configurationPath, AspirateSettings.FileName);
+
+        if (!fileSystem.File.Exists(configurationFile))
+        {
+            return null;
+        }
+
+        var configurationJson = fileSystem.File.ReadAllText(configurationFile);
+
+        var aspirateSettings = JsonSerializer.Deserialize<AspirateSettings>(configurationJson, _jsonSerializerOptions);
+
+        return aspirateSettings;
+    }
+
+    public void SaveConfigurationFile(AspirateSettings settings, string appHostPath)
+    {
+        var configurationPath = fileSystem.NormalizePath(appHostPath);
+        var configurationFile = fileSystem.Path.Combine(configurationPath, AspirateSettings.FileName);
+
+        if (fileSystem.File.Exists(configurationFile))
+        {
+            HandleExistingConfiguration(appHostPath);
+        }
+
+        var configurationJson = JsonSerializer.Serialize(settings, _jsonSerializerOptions);
+
+        fileSystem.File.WriteAllText(configurationFile, configurationJson);
+
+        LogConfigurationSaved(configurationFile);
+    }
+
+    private void LogExistingConfigurationFound() =>
+        console.MarkupLine($"\r\n[bold yellow] {EmojiLiterals.Warning} Existing configuration found.[/]");
+
+    private void LogExistingConfigurationDeleted() =>
+        console.MarkupLine($"\r\n[bold green] {EmojiLiterals.Warning} Existing configuration has been [red]deleted[/].[/]");
+
+    private void LogExistingNotDeleted() =>
+        console.MarkupLine($"\r\n[bold red] {EmojiLiterals.Warning} Existing configuration has not been removed - aspirate will now terminate.[/]");
+
+    private void LogConfigurationSaved(string path) =>
+        console.MarkupLine($"\r\n[bold green]({EmojiLiterals.CheckMark}) Done:[/] Configuration for aspirate has been bootstrapped successfully at [blue]'{path}'.[/]");
+}

--- a/src/Aspirate.Cli/Services/AspireManifestCompositionService.cs
+++ b/src/Aspirate.Cli/Services/AspireManifestCompositionService.cs
@@ -10,21 +10,16 @@ public class AspireManifestCompositionService(IFileSystem fileSystem, IAnsiConso
         _stdErrBuffer.Clear();
         _stdOutBuffer.Clear();
 
-        if (appHostProject.StartsWith('.'))
-        {
-            var currentDirectory = fileSystem.Directory.GetCurrentDirectory();
-            var normalizedProjectPath = appHostProject.Replace('\\', fileSystem.Path.DirectorySeparatorChar);
-            appHostProject = fileSystem.Path.Combine(currentDirectory, normalizedProjectPath);
-        }
+        var normalizedPath = fileSystem.NormalizePath(appHostProject);
 
         var argumentsBuilder = ArgumentsBuilder.Create()
             .AppendArgument(DotNetSdkLiterals.RunArgument, string.Empty, quoteValue: false)
-            .AppendArgument(DotNetSdkLiterals.ProjectArgument, appHostProject)
+            .AppendArgument(DotNetSdkLiterals.ProjectArgument, normalizedPath)
             .AppendArgument(DotNetSdkLiterals.ArgumentDelimiter, string.Empty, quoteValue: false)
             .AppendArgument(DotNetSdkLiterals.PublisherArgument, AspireLiterals.ManifestPublisherArgument, quoteValue: false)
             .AppendArgument(DotNetSdkLiterals.OutputPathArgument, AspireLiterals.DefaultManifestFile, quoteValue: false);
 
-        var outputFile = await BuildManifest(appHostProject, argumentsBuilder);
+        var outputFile = await BuildManifest(normalizedPath, argumentsBuilder);
 
         return (true, outputFile);
     }

--- a/src/Aspirate.Cli/Services/ContainerCompositionService.cs
+++ b/src/Aspirate.Cli/Services/ContainerCompositionService.cs
@@ -10,9 +10,7 @@ public sealed class ContainerCompositionService(IFileSystem filesystem, IAnsiCon
         _stdErrBuffer.Clear();
         _stdOutBuffer.Clear();
 
-        var currentDirectory = filesystem.Directory.GetCurrentDirectory();
-        var normalizedProjectPath = project.Path.Replace('\\', filesystem.Path.DirectorySeparatorChar);
-        var fullProjectPath = filesystem.Path.Combine(currentDirectory, normalizedProjectPath);
+        var fullProjectPath = filesystem.NormalizePath(project.Path);
 
         var argumentsBuilder = ArgumentsBuilder.Create();
 

--- a/src/Aspirate.Cli/Services/ManifestFileParserService.cs
+++ b/src/Aspirate.Cli/Services/ManifestFileParserService.cs
@@ -32,7 +32,7 @@ public class ManifestFileParserService(
 
         if (!fileSystem.File.Exists(manifestFile))
         {
-            throw new InvalidOperationException("The input file does not exist.");
+            throw new InvalidOperationException($"The manifest file could not be loaded from: '{manifestFile}'");
         }
 
         var inputJson = fileSystem.File.ReadAllText(manifestFile);

--- a/src/Aspirate.Cli/Services/ProjectPropertyService.cs
+++ b/src/Aspirate.Cli/Services/ProjectPropertyService.cs
@@ -6,10 +6,8 @@ public sealed class ProjectPropertyService(IFileSystem filesystem) : IProjectPro
 
     public async Task<string?> GetProjectPropertiesAsync(string projectPath, params string[] propertyNames)
     {
-        var currentDirectory = filesystem.Directory.GetCurrentDirectory();
-        var normalizedProjectPath = projectPath.Replace('\\', filesystem.Path.DirectorySeparatorChar);
-        var fullProjectPath = filesystem.Path.Combine(currentDirectory, normalizedProjectPath);
-        var projectDirectory = filesystem.Path.GetDirectoryName(fullProjectPath) ?? throw new($"Could not get directory name from {fullProjectPath}");
+        var fullProjectPath = filesystem.NormalizePath(projectPath);
+        var projectDirectory = filesystem.Path.GetDirectoryName(fullProjectPath);
         var propertyValues = await ExecuteDotnetMsBuildGetPropertyCommand(projectDirectory, propertyNames);
 
         return propertyValues ?? null;

--- a/src/Aspirate.Contracts/Aspirate.Contracts.csproj
+++ b/src/Aspirate.Contracts/Aspirate.Contracts.csproj
@@ -12,8 +12,4 @@
     <PackageReference Include="TestableIO.System.IO.Abstractions.Wrappers" />
   </ItemGroup>
 
-  <ItemGroup>
-    <Folder Include="Models\Containers\" />
-  </ItemGroup>
-
 </Project>

--- a/src/Aspirate.Contracts/GlobalUsings.cs
+++ b/src/Aspirate.Contracts/GlobalUsings.cs
@@ -4,6 +4,7 @@ global using System.Text.Json;
 global using System.Text.Json.Serialization;
 global using Aspirate.Contracts.Interfaces;
 global using Aspirate.Contracts.Literals;
+global using Aspirate.Contracts.Models.Aspirate;
 global using Aspirate.Contracts.Models.AspireManifests;
 global using Aspirate.Contracts.Models.AspireManifests.Components.V0;
 global using Aspirate.Contracts.Models.MsBuild;

--- a/src/Aspirate.Contracts/Interfaces/IAspirateConfigurationService.cs
+++ b/src/Aspirate.Contracts/Interfaces/IAspirateConfigurationService.cs
@@ -1,0 +1,8 @@
+namespace Aspirate.Contracts.Interfaces;
+
+public interface IAspirateConfigurationService
+{
+    void HandleExistingConfiguration(string appHostPath);
+    void SaveConfigurationFile(AspirateSettings settings, string appHostPath);
+    AspirateSettings? LoadConfigurationFile(string appHostPath);
+}

--- a/src/Aspirate.Contracts/Interfaces/IContainerDetailsService.cs
+++ b/src/Aspirate.Contracts/Interfaces/IContainerDetailsService.cs
@@ -1,5 +1,5 @@
 namespace Aspirate.Contracts.Interfaces;
 public interface IContainerDetailsService
 {
-    Task<MsBuildContainerProperties> GetContainerDetails(string resourceName, Project project);
+    Task<MsBuildContainerProperties> GetContainerDetails(string resourceName, Project project, AspirateSettings? aspirateSettings);
 }

--- a/src/Aspirate.Contracts/Interfaces/IProcessor.cs
+++ b/src/Aspirate.Contracts/Interfaces/IProcessor.cs
@@ -17,5 +17,5 @@ public interface IProcessor
     /// <summary>
     /// Produces the output manifest file.
     /// </summary>
-    Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath);
+    Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, AspirateSettings? aspirateSettings = null);
 }

--- a/src/Aspirate.Contracts/Literals/AspirateLiterals.cs
+++ b/src/Aspirate.Contracts/Literals/AspirateLiterals.cs
@@ -1,0 +1,6 @@
+namespace Aspirate.Contracts.Literals;
+
+public static class AspirateLiterals
+{
+    
+}

--- a/src/Aspirate.Contracts/Literals/EmojiLiterals.cs
+++ b/src/Aspirate.Contracts/Literals/EmojiLiterals.cs
@@ -6,4 +6,5 @@ public static class EmojiLiterals
     public const string CheckMark = Emoji.Known.CheckMark;
     public const string Smiley = Emoji.Known.SmilingFace;
     public const string Rocket = Emoji.Known.Rocket;
+    public const string Warning = Emoji.Known.Warning;
 }

--- a/src/Aspirate.Contracts/Models/Aspirate/AspirateContainerSettings.cs
+++ b/src/Aspirate.Contracts/Models/Aspirate/AspirateContainerSettings.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Contracts.Models.Aspirate;
+
+public class AspirateContainerSettings
+{
+    public string? Registry { get; set; }
+    public string? Tag { get; set; }
+}

--- a/src/Aspirate.Contracts/Models/Aspirate/AspirateSettings.cs
+++ b/src/Aspirate.Contracts/Models/Aspirate/AspirateSettings.cs
@@ -1,0 +1,10 @@
+namespace Aspirate.Contracts.Models.Aspirate;
+
+public class AspirateSettings
+{
+    public const string FileName = "aspirate.json";
+
+    public string? TemplatePath { get; set; }
+
+    public AspirateContainerSettings? ContainerSettings { get; set; } = new();
+}


### PR DESCRIPTION
- the init command 'aspirate init -p .' allows bootstrapping default configuration options for all projects which the tool will process.
currently it supports:
ContainerRegistry - setting this means you do not need one in your csproj
ContainerTag - will override the container tag used if not in your csproj - if not specified in settings, will fall-back to latest
TemplatePath - this customises the path used when loading templates that get transformed to manifests, you can take the templates folder from the source, and modify to your hearts content with all your custom changes, and as long as you don't remove the placeholders, aspirate will use those instead of its built in. More on this and possible use cases (such as adding jobs to create databases etc) when we have docs....
