### PR TITLE
Command Work

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,22 +1,15 @@
 # Aspirate (Aspir8)
-### Convert Aspire Configuration file to Kustomize Manifests for K8s.
+### Automate deployment of an Aspire AppHost to a Kubernetes Cluster.
 
-Test with:
+---
+### To Install as a global tool
+
 ```bash
-dotnet run -- e2e -p ./Example/AppHost -o ./output
+dotnet tool install -g aspirate
 ```
 
 ---
-### To Install as a global tool, until this hits release phase
-
-```bash
-gh repo clone prom3theu5/aspirational-manifests
-cd aspirational-manifests
-dotnet pack -c Release -o ./artifacts
-dotnet tool install -g aspirate --add-source ./artifacts/
-```
----
-### Generating Manifests (end-to-end)
+### Generating Manifests (apply)
 #### ContainerRegistry
 You're csproj files (projects) that will be build as containers **MUST** contain ContainerRegistry as a minimum, or the sdk will raise a CONTAINERS1013 error.
 To get around this - you can either add it as required, or use the 'init' command.
@@ -36,16 +29,32 @@ from withinn your AppHost directory - and it'll ask you which settings you'd lik
 #### Produce Manifests
 Navigate to your Aspire project's AppHost directory, and run:
 ```bash
-aspirate e2e -o ./output
+aspirate generate
 ```
-Your manifests will be in the AppHost/output directory
+Your manifests will be in the AppHost/aspirate-output directory
+
+---
+> **_INFORMATION:_**  Both the following commands will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
+
+#### Apply Manifests
+To apply the manifests to your cluster, run:
+```bash
+aspirate apply
+```
+
+#### Remove Manifests
+To remove the manifests from your cluster, run:
+```bash
+aspirate destroy
+```
+
 ---
 ### Uninstall tool
 ```bash
 dotnet tool uninstall -g aspirate
 ```
----
 
+---
 ### Configuring the Windows Terminal For Unicode and Emoji Support
 
 Windows Terminal supports Unicode and Emoji. However, the shells such as Powershell and cmd.exe do not.

--- a/src/Aspirate.Cli/Commands/Apply/ApplyCommand.cs
+++ b/src/Aspirate.Cli/Commands/Apply/ApplyCommand.cs
@@ -1,0 +1,42 @@
+namespace Aspirate.Cli.Commands.Apply;
+
+/// <summary>
+/// The command to convert Aspire Manifests to Kustomize Manifests.
+/// </summary>
+public sealed class ApplyCommand(
+    IAnsiConsole console,
+    IKubeCtlService kubeCtlService,
+    IServiceProvider serviceProvider) : AsyncCommand<ApplyInput>
+{
+    public const string CommandName = "apply";
+    public const string CommandDescription = "Deployes the manifests to the kubernetes context after asking which you'd like to use.";
+
+    public override async Task<int> ExecuteAsync(CommandContext context, ApplyInput settings)
+    {
+        await HandleDeployment(settings);
+
+        console.LogCommandCompleted();
+
+        return 0;
+    }
+
+    private async Task HandleDeployment(ApplyInput settings)
+    {
+        console.WriteLine();
+        var shouldDeploy = console.Confirm("[bold]Would you like to deploy the generated manifests to a kubernetes cluster defined in your kubeconfig file?[/]");
+        if (!shouldDeploy)
+        {
+            return;
+        }
+
+        var successfullySelectedCluster = await kubeCtlService.SelectKubernetesContextForDeployment();
+
+        if (!successfullySelectedCluster)
+        {
+            return;
+        }
+
+        await kubeCtlService.ApplyManifests(settings.OutputPathFlag);
+        console.LogApplyCommandCompleted(kubeCtlService.GetActiveContextName());
+    }
+}

--- a/src/Aspirate.Cli/Commands/Apply/ApplyInput.cs
+++ b/src/Aspirate.Cli/Commands/Apply/ApplyInput.cs
@@ -1,0 +1,11 @@
+namespace Aspirate.Cli.Commands.Apply;
+
+public sealed class ApplyInput : CommandSettings
+{
+    /// <summary>
+    /// The path to the output kustomize manifest
+    /// </summary>
+    [CommandOption("-k|--kustomize")]
+    [Description("The input path for the generated kustomize manifests")]
+    public string OutputPathFlag { get; init; } = AspirateLiterals.DefaultOutputPath;
+}

--- a/src/Aspirate.Cli/Commands/Apply/ApplyLogExtensions.cs
+++ b/src/Aspirate.Cli/Commands/Apply/ApplyLogExtensions.cs
@@ -1,0 +1,10 @@
+namespace Aspirate.Cli.Commands.Apply;
+
+public static class ApplyLogExtensions
+{
+    public static void LogApplyCommandCompleted(this IAnsiConsole console, string cluster) =>
+        console.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments successfully applied to cluster [blue]'{cluster}'[/]");
+
+    public static void LogCommandCompleted(this IAnsiConsole console) =>
+        console.MarkupLine($"\r\n[bold] {EmojiLiterals.Rocket} Execution Completed - Happy Deployment {EmojiLiterals.Smiley}[/]");
+}

--- a/src/Aspirate.Cli/Commands/Destroy/DestroyCommand.cs
+++ b/src/Aspirate.Cli/Commands/Destroy/DestroyCommand.cs
@@ -1,0 +1,42 @@
+namespace Aspirate.Cli.Commands.Destroy;
+
+/// <summary>
+/// The command to roll back an apply.
+/// </summary>
+public sealed class DestroyCommand(
+    IAnsiConsole console,
+    IKubeCtlService kubeCtlService,
+    IServiceProvider serviceProvider) : AsyncCommand<DestroyInput>
+{
+    public const string CommandName = "destroy";
+    public const string CommandDescription = "Removes the manifests from your cluster.";
+
+    public override async Task<int> ExecuteAsync(CommandContext context, DestroyInput settings)
+    {
+        await HandleDeployment(settings);
+
+        console.LogCommandCompleted();
+
+        return 0;
+    }
+
+    private async Task HandleDeployment(DestroyInput settings)
+    {
+        console.WriteLine();
+        var shouldDeploy = console.Confirm("[bold]Would you like to remove the deployed manifests from a kubernetes cluster defined in your kubeconfig file?[/]");
+        if (!shouldDeploy)
+        {
+            return;
+        }
+
+        var successfullySelectedCluster = await kubeCtlService.SelectKubernetesContextForDeployment();
+
+        if (!successfullySelectedCluster)
+        {
+            return;
+        }
+
+        await kubeCtlService.RemoveManifests(settings.OutputPathFlag);
+        console.LogDestroyCommandCompleted(kubeCtlService.GetActiveContextName());
+    }
+}

--- a/src/Aspirate.Cli/Commands/Destroy/DestroyInput.cs
+++ b/src/Aspirate.Cli/Commands/Destroy/DestroyInput.cs
@@ -1,0 +1,11 @@
+namespace Aspirate.Cli.Commands.Destroy;
+
+public sealed class DestroyInput : CommandSettings
+{
+    /// <summary>
+    /// The path to the input kustomize manifest
+    /// </summary>
+    [CommandOption("-k|--kustomize")]
+    [Description("The input path for the kustomize manifests")]
+    public string OutputPathFlag { get; init; } = AspirateLiterals.DefaultOutputPath;
+}

--- a/src/Aspirate.Cli/Commands/Destroy/DestroyLogExtensions.cs
+++ b/src/Aspirate.Cli/Commands/Destroy/DestroyLogExtensions.cs
@@ -1,0 +1,10 @@
+namespace Aspirate.Cli.Commands.Destroy;
+
+public static class DestroyLogExtensions
+{
+    public static void LogDestroyCommandCompleted(this IAnsiConsole console, string cluster) =>
+        console.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments removed from cluster [blue]'{cluster}'[/]");
+
+    public static void LogCommandCompleted(this IAnsiConsole console) =>
+        console.MarkupLine($"\r\n[bold] {EmojiLiterals.Rocket} Execution Completed[/]");
+}

--- a/src/Aspirate.Cli/Commands/Generate/GenerateInput.cs
+++ b/src/Aspirate.Cli/Commands/Generate/GenerateInput.cs
@@ -1,21 +1,18 @@
-namespace Aspirate.Cli.Commands.EndToEnd;
+namespace Aspirate.Cli.Commands.Generate;
 
-/// <summary>
-/// The input for the EndToEndCommand
-/// </summary>
-public sealed class EndToEndInput : CommandSettings
+public sealed class GenerateInput : CommandSettings
 {
     /// <summary>
     /// The path to the Aspire manifest
     /// </summary>
     [CommandOption("-p|--project")]
     [Description("The path to the Aspire AppHost project")]
-    public string PathToAspireProjectFlag { get; init; } = ".";
+    public string PathToAspireProjectFlag { get; init; } = AspirateLiterals.DefaultAspireProjectPath;
 
     /// <summary>
     /// The path to the output kustomize manifest
     /// </summary>
     [CommandOption("-o|--output")]
     [Description("The output path for the generated kustomize manifests")]
-    public required string OutputPathFlag { get; init; }
+    public string OutputPathFlag { get; init; } = AspirateLiterals.DefaultOutputPath;
 }

--- a/src/Aspirate.Cli/Commands/Generate/GenerateLogExtensions.cs
+++ b/src/Aspirate.Cli/Commands/Generate/GenerateLogExtensions.cs
@@ -1,6 +1,6 @@
-namespace Aspirate.Cli.Commands.EndToEnd;
+namespace Aspirate.Cli.Commands.Generate;
 
-public static class EndToEndLogExtensions
+public static class GenerateLogExtensions
 {
     public static void LogGeneratingManifests(this IAnsiConsole console) =>
         console.MarkupLine("\r\n[bold]Generating kustomize manifests to run against your kubernetes cluster:[/]\r\n");

--- a/src/Aspirate.Cli/Commands/Init/InitCommand.cs
+++ b/src/Aspirate.Cli/Commands/Init/InitCommand.cs
@@ -6,8 +6,8 @@ public sealed class InitCommand(
     IFileSystem filesystem,
     IServiceProvider serviceProvider) : AsyncCommand<InitInput>
 {
-    public const string InitCommandName = "init";
-    public const string InitDescription = "Initializes aspirate settings within your AppHost directory.";
+    public const string CommandName = "init";
+    public const string CommandDescription = "Initializes aspirate settings within your AppHost directory.";
 
     public override Task<int> ExecuteAsync(CommandContext context, InitInput settings)
     {

--- a/src/Aspirate.Cli/Commands/Init/InitInput.cs
+++ b/src/Aspirate.Cli/Commands/Init/InitInput.cs
@@ -1,8 +1,5 @@
 namespace Aspirate.Cli.Commands.Init;
 
-/// <summary>
-/// The input for the EndToEndCommand
-/// </summary>
 public sealed class InitInput : CommandSettings
 {
     /// <summary>
@@ -10,5 +7,5 @@ public sealed class InitInput : CommandSettings
     /// </summary>
     [CommandOption("-p|--project")]
     [Description("The path to the Aspire AppHost project")]
-    public string PathToAspireProjectFlag { get; init; } = ".";
+    public string PathToAspireProjectFlag { get; init; } = AspirateLiterals.DefaultAspireProjectPath;
 }

--- a/src/Aspirate.Cli/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Cli/Extensions/ServiceCollectionExtensions.cs
@@ -7,6 +7,7 @@ internal static class ServiceCollectionExtensions
             .AddAspireManifestSupport()
             .AddAspirateConfigurationSupport()
             .AddContainerSupport()
+            .AddKubeCtlSupport()
             .AddProcessors();
 
     private static IServiceCollection AddSpectreConsole(this IServiceCollection services) =>
@@ -21,6 +22,10 @@ internal static class ServiceCollectionExtensions
     private static IServiceCollection AddAspirateConfigurationSupport(this IServiceCollection services) =>
         services
             .AddSingleton<IAspirateConfigurationService, AspirateConfigurationService>();
+
+    private static IServiceCollection AddKubeCtlSupport(this IServiceCollection services) =>
+        services
+            .AddSingleton<IKubeCtlService, KubeCtlService>();
 
     private static IServiceCollection AddContainerSupport(this IServiceCollection services) =>
         services

--- a/src/Aspirate.Cli/GlobalUsings.cs
+++ b/src/Aspirate.Cli/GlobalUsings.cs
@@ -4,7 +4,9 @@ global using System.IO.Abstractions;
 global using System.ComponentModel;
 global using System.Text;
 global using System.Text.Json;
-global using Aspirate.Cli.Commands.EndToEnd;
+global using Aspirate.Cli.Commands.Apply;
+global using Aspirate.Cli.Commands.Destroy;
+global using Aspirate.Cli.Commands.Generate;
 global using Aspirate.Cli.Commands.Init;
 global using Microsoft.Extensions.DependencyInjection;
 
@@ -15,6 +17,7 @@ global using Aspirate.Cli.Processors.Components.Project;
 global using Aspirate.Cli.Processors.Components.RabbitMQ;
 global using Aspirate.Cli.Processors.Components.Redis;
 global using Aspirate.Cli.Services;
+global using Aspirate.Contracts.Extensions;
 global using Aspirate.Contracts.Interfaces;
 global using Aspirate.Contracts.Literals;
 global using Aspirate.Contracts.Models;

--- a/src/Aspirate.Cli/Program.cs
+++ b/src/Aspirate.Cli/Program.cs
@@ -8,16 +8,26 @@ var app = new CommandApp(registrar);
 app.Configure(
     config =>
     {
-        config.AddCommand<EndToEndCommand>(EndToEndCommand.EndToEndCommandName)
-            .WithDescription(EndToEndCommand.EndToEndDescription)
-            .WithAlias("e2e")
-            .WithExample(["e2e", "-o", "./output"])
-            .WithExample(["e2e", "-p", "/path/to/appHost", "-o", "./output"]);
-
-        config.AddCommand<InitCommand>(InitCommand.InitCommandName)
-            .WithDescription(InitCommand.InitDescription)
+        config.AddCommand<InitCommand>(InitCommand.CommandName)
+            .WithDescription(InitCommand.CommandDescription)
             .WithExample(["init"])
             .WithExample(["init", "-p", "/path/to/appHost"]);
+
+        config.AddCommand<GenerateCommand>(GenerateCommand.CommandName)
+            .WithDescription(GenerateCommand.CommandDescription)
+            .WithAlias("gen")
+            .WithExample(["generate"])
+            .WithExample(["generate", "-p", "/path/to/appHost", "-o", "./output"]);
+
+        config.AddCommand<ApplyCommand>(ApplyCommand.CommandName)
+            .WithDescription(ApplyCommand.CommandDescription)
+            .WithExample(["apply"])
+            .WithExample(["apply", "-k", "./output"]);
+
+        config.AddCommand<DestroyCommand>(DestroyCommand.CommandName)
+            .WithDescription(DestroyCommand.CommandDescription)
+            .WithExample(["destroy"])
+            .WithExample(["destroy", "-k", "./output"]);
 
         config.SetApplicationName("aspirate");
     });

--- a/src/Aspirate.Cli/Properties/launchSettings.json
+++ b/src/Aspirate.Cli/Properties/launchSettings.json
@@ -1,14 +1,26 @@
 {
   "profiles": {
-    "end-to-end": {
-      "commandName": "Project",
-      "commandLineArgs": "e2e -o ./output",
-      "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
-      "hotReloadEnabled": false
-    },
     "init": {
       "commandName": "Project",
       "commandLineArgs": "init",
+      "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
+      "hotReloadEnabled": false
+    },
+    "generate": {
+      "commandName": "Project",
+      "commandLineArgs": "generate",
+      "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
+      "hotReloadEnabled": false
+    },
+    "apply": {
+      "commandName": "Project",
+      "commandLineArgs": "apply",
+      "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
+      "hotReloadEnabled": false
+    },
+    "destroy": {
+      "commandName": "Project",
+      "commandLineArgs": "destroy",
       "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
       "hotReloadEnabled": false
     }

--- a/src/Aspirate.Cli/Services/KubeCtlService.cs
+++ b/src/Aspirate.Cli/Services/KubeCtlService.cs
@@ -1,0 +1,231 @@
+namespace Aspirate.Cli.Services;
+
+public class KubeCtlService(IFileSystem filesystem, IAnsiConsole console) : IKubeCtlService
+{
+    private readonly StringBuilder _stdOutBuffer = new();
+    private readonly StringBuilder _stdErrBuffer = new();
+
+    private string? _activeContextName;
+
+    public async Task<bool> SelectKubernetesContextForDeployment()
+    {
+        var contexts = await GatherContexts();
+
+        if (contexts.Count == 0)
+        {
+            console.MarkupLine("[red]No Kubernetes contexts found in kubeconfig[/]");
+            return false;
+        }
+
+        _activeContextName = SelectKubernetesContextToUse(contexts!);
+
+        return await SetActiveContext();
+    }
+
+    public string GetActiveContextName() => _activeContextName ?? string.Empty;
+
+    public async Task<bool> ApplyManifests(string outputFolder)
+    {
+        if (!EnsureActiveContextIsSet())
+        {
+            return false;
+        }
+
+        var fullOutputPath = filesystem.GetFullPath(outputFolder);
+
+        _stdErrBuffer.Clear();
+        _stdOutBuffer.Clear();
+
+        var argumentsBuilder = ArgumentsBuilder.Create()
+            .AppendArgument(KubeCtlLiterals.KubeCtlApplyArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlKustomizeManifestsArgument, fullOutputPath, quoteValue: false);
+
+        var arguments = argumentsBuilder.RenderArguments();
+
+        var executeCommand = CliWrap.Cli.Wrap(KubeCtlLiterals.KubeCtlCommand)
+            .WithArguments(arguments)
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(_stdOutBuffer))
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(_stdErrBuffer));
+
+        await foreach(var cmdEvent in executeCommand.ListenAsync())
+        {
+            switch (cmdEvent)
+            {
+                case StartedCommandEvent _:
+                    console.WriteLine();
+                    console.MarkupLine($"[cyan]Executing: [green]{KubeCtlLiterals.KubeCtlCommand} {arguments}[/] against kubernetes context [blue]{_activeContextName}.[/][/]");
+                    break;
+                case StandardOutputCommandEvent stdOut:
+                    console.WriteLine(stdOut.Text);
+                    break;
+                case StandardErrorCommandEvent stdErr:
+                    console.MarkupLine($"[red]{stdErr.Text}[/]");
+                    break;
+                case ExitedCommandEvent exited:
+                    if (exited.ExitCode != 0)
+                    {
+                        console.MarkupLine($"[red]Failed to deploy manifests in [blue]'{fullOutputPath}'[/][/]");
+                        return false;
+                    }
+                    break;
+            }
+        }
+
+        _stdErrBuffer.Clear();
+        _stdOutBuffer.Clear();
+
+        return true;
+    }
+
+    public async Task<bool> RemoveManifests(string outputFolder)
+    {
+        if (!EnsureActiveContextIsSet())
+        {
+            return false;
+        }
+
+        var fullOutputPath = filesystem.GetFullPath(outputFolder);
+
+        _stdErrBuffer.Clear();
+        _stdOutBuffer.Clear();
+
+        var argumentsBuilder = ArgumentsBuilder.Create()
+            .AppendArgument(KubeCtlLiterals.KubeCtlDeleteArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlKustomizeManifestsArgument, fullOutputPath, quoteValue: false);
+
+        var arguments = argumentsBuilder.RenderArguments();
+
+        var executeCommand = CliWrap.Cli.Wrap(KubeCtlLiterals.KubeCtlCommand)
+            .WithArguments(arguments)
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(_stdOutBuffer))
+            .WithStandardErrorPipe(PipeTarget.ToStringBuilder(_stdErrBuffer));
+
+        await foreach(var cmdEvent in executeCommand.ListenAsync())
+        {
+            switch (cmdEvent)
+            {
+                case StartedCommandEvent _:
+                    console.WriteLine();
+                    console.MarkupLine($"[cyan]Executing: [green]{KubeCtlLiterals.KubeCtlCommand} {arguments}[/] against kubernetes context [blue]{_activeContextName}.[/][/]");
+                    break;
+                case StandardOutputCommandEvent stdOut:
+                    console.WriteLine(stdOut.Text);
+                    break;
+                case StandardErrorCommandEvent stdErr:
+                    console.MarkupLine($"[red]{stdErr.Text}[/]");
+                    break;
+                case ExitedCommandEvent exited:
+                    if (exited.ExitCode != 0)
+                    {
+                        console.MarkupLine($"[red]Failed to remove manifests in [blue]'{fullOutputPath}'[/][/]");
+                        return false;
+                    }
+                    break;
+            }
+        }
+
+        _stdErrBuffer.Clear();
+        _stdOutBuffer.Clear();
+
+        return true;
+    }
+
+    private async Task<IReadOnlyCollection<string?>> GatherContexts()
+    {
+        _stdOutBuffer.Clear();
+
+        var argumentsBuilder = ArgumentsBuilder.Create()
+            .AppendArgument(KubeCtlLiterals.KubeCtlConfigArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlViewArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlOutputArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlOutputJsonArgument, string.Empty, quoteValue: false);
+
+        var arguments = argumentsBuilder.RenderArguments();
+
+        var commandResult = await CliWrap.Cli.Wrap(KubeCtlLiterals.KubeCtlCommand)
+            .WithArguments(arguments)
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(_stdOutBuffer))
+            .ExecuteAsync();
+
+        if (commandResult.ExitCode != 0)
+        {
+            console.MarkupLine("[red]Failed to gather Kubernetes contexts from kubeconfig[/]");
+        }
+
+        var contexts = ParseResponseAsContextList(_stdOutBuffer.ToString());
+        _stdOutBuffer.Clear();
+
+        return contexts;
+    }
+
+    private async Task<bool> SetActiveContext()
+    {
+        if (!EnsureActiveContextIsSet())
+        {
+            return false;
+        }
+
+        _stdOutBuffer.Clear();
+
+        var argumentsBuilder = ArgumentsBuilder.Create()
+            .AppendArgument(KubeCtlLiterals.KubeCtlConfigArgument, string.Empty, quoteValue: false)
+            .AppendArgument(KubeCtlLiterals.KubeCtlUseContextArgument, _activeContextName, quoteValue: false);
+
+        var arguments = argumentsBuilder.RenderArguments();
+
+        var commandResult = await CliWrap.Cli.Wrap(KubeCtlLiterals.KubeCtlCommand)
+            .WithArguments(arguments)
+            .WithValidation(CommandResultValidation.None)
+            .WithStandardOutputPipe(PipeTarget.ToStringBuilder(_stdOutBuffer))
+            .ExecuteAsync();
+
+        if (commandResult.ExitCode != 0)
+        {
+            console.MarkupLine($"[red]Failed to set Active Kubernetes Context to [blue]'{_activeContextName}'[/][/]");
+            return false;
+        }
+
+        console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done:[/] Successfully set the Active Kubernetes Context to [blue]'{_activeContextName}'[/]");
+        return true;
+    }
+
+    private bool EnsureActiveContextIsSet()
+    {
+        if (string.IsNullOrEmpty(_activeContextName))
+        {
+            console.MarkupLine("[red]Active context has not been set.[/]");
+            return false;
+        }
+
+        return true;
+    }
+
+    private static List<string?> ParseResponseAsContextList(string jsonString)
+    {
+        try
+        {
+            var jsonDoc = JsonDocument.Parse(jsonString);
+            var root = jsonDoc.RootElement;
+            var contexts = root.GetProperty(KubeCtlLiterals.KubeCtlContextsProperty);
+
+            return contexts.EnumerateArray()
+                .Select(context => context.GetProperty(KubeCtlLiterals.KubeCtlNameProperty).GetString())
+                .ToList();
+        }
+        catch
+        {
+            return [];
+        }
+    }
+
+    private string SelectKubernetesContextToUse(IReadOnlyCollection<string> contextNames) =>
+        console.Prompt(
+            new SelectionPrompt<string>()
+                .Title("Select [green]kubernetes context[/] to use for deployment")
+                .PageSize(10)
+                .MoreChoicesText("[grey](Move up and down to reveal more contexts)[/]")
+                .AddChoices(contextNames));
+}

--- a/src/Aspirate.Cli/Services/ManifestFileParserService.cs
+++ b/src/Aspirate.Cli/Services/ManifestFileParserService.cs
@@ -76,6 +76,18 @@ public class ManifestFileParserService(
         return resources;
     }
 
+    public List<string> SelectManifestItemsToProcess(IEnumerable<string> manifestItems) =>
+        console.Prompt(
+            new MultiSelectionPrompt<string>()
+                .Title("Select [green]components[/] to process from the loaded file")
+                .PageSize(10)
+                .Required()
+                .MoreChoicesText("[grey](Move up and down to reveal more components)[/]")
+                .InstructionsText(
+                    "[grey](Press [blue]<space>[/] to toggle a component, " +
+                    "[green]<enter>[/] to accept)[/]")
+                .AddChoiceGroup("All Components", manifestItems));
+
     private static void ReplacePlaceholdersInParsedResources(Dictionary<string, Resource> resources)
     {
         foreach (var resource in resources.Values)

--- a/src/Aspirate.Contracts/Extensions/PathExtensions.cs
+++ b/src/Aspirate.Contracts/Extensions/PathExtensions.cs
@@ -1,4 +1,4 @@
-namespace Aspirate.Cli.Extensions;
+namespace Aspirate.Contracts.Extensions;
 
 public static class PathExtensions
 {

--- a/src/Aspirate.Contracts/Interfaces/IKubeCtlService.cs
+++ b/src/Aspirate.Contracts/Interfaces/IKubeCtlService.cs
@@ -1,0 +1,9 @@
+namespace Aspirate.Contracts.Interfaces;
+
+public interface IKubeCtlService
+{
+    Task<bool> SelectKubernetesContextForDeployment();
+    Task<bool> ApplyManifests(string outputFolder);
+    Task<bool> RemoveManifests(string outputFolder);
+    string GetActiveContextName();
+}

--- a/src/Aspirate.Contracts/Interfaces/IManifestFileParserService.cs
+++ b/src/Aspirate.Contracts/Interfaces/IManifestFileParserService.cs
@@ -12,4 +12,11 @@ public interface IManifestFileParserService
     /// <returns>A collection of resources in a dictionary.</returns>
     /// <exception cref="InvalidOperationException">Throw if the file does not exist.</exception>
     Dictionary<string, Resource> LoadAndParseAspireManifest(string manifestFile);
+
+    /// <summary>
+    /// Selects the manifest items to process.
+    /// </summary>
+    /// <param name="manifestItems">All possible items from the manifest.</param>
+    /// <returns></returns>
+    List<string> SelectManifestItemsToProcess(IEnumerable<string> manifestItems);
 }

--- a/src/Aspirate.Contracts/Literals/AspirateLiterals.cs
+++ b/src/Aspirate.Contracts/Literals/AspirateLiterals.cs
@@ -2,5 +2,6 @@ namespace Aspirate.Contracts.Literals;
 
 public static class AspirateLiterals
 {
-    
+    public const string DefaultOutputPath = "./aspirate-output";
+    public const string DefaultAspireProjectPath = ".";
 }

--- a/src/Aspirate.Contracts/Literals/KubeCtlLiterals.cs
+++ b/src/Aspirate.Contracts/Literals/KubeCtlLiterals.cs
@@ -1,0 +1,19 @@
+namespace Aspirate.Contracts.Literals;
+
+public static class KubeCtlLiterals
+{
+    public const string KubeCtlCommand = "kubectl";
+
+    public const string KubeCtlApplyArgument = "apply";
+    public const string KubeCtlDeleteArgument = "delete";
+    public const string KubeCtlConfigArgument = "config";
+    public const string KubeCtlViewArgument = "view";
+    public const string KubeCtlOutputArgument = "-o";
+    public const string KubeCtlOutputJsonArgument = "json";
+    public const string KubeCtlUseContextArgument = "use-context";
+    public const string KubeCtlKustomizeManifestsArgument = "-k";
+
+    public const string KubeCtlContextsProperty = "contexts";
+    public const string KubeCtlNameProperty = "name";
+
+}

--- a/src/Aspirate.Contracts/Processors/BaseProcessor.cs
+++ b/src/Aspirate.Contracts/Processors/BaseProcessor.cs
@@ -1,3 +1,5 @@
+using Aspirate.Contracts.Extensions;
+
 namespace Aspirate.Contracts.Processors;
 
 /// <summary>
@@ -109,5 +111,5 @@ public abstract class BaseProcessor<TTemplateData> : IProcessor where TTemplateD
         _fileSystem.Path.Combine(aspirateSettings?.TemplatePath ?? _defaultTemplatePath, templateFile);
 
     protected void LogCompletion(string outputPath) =>
-        _console.LogCompletion(outputPath);
+        _console.LogCompletion(_fileSystem.GetFullPath(outputPath));
 }


### PR DESCRIPTION
- Rename the e2e command to 'generate'
- introduce the 'apply' command to allow deployment of manifests on the cluster context you select during execution of the command.
- introduce the 'destroy' command to allow removal of deployed manifests on the cluster context you select during execution of the command.
- introduces the KubeCtlService, along with literals, to facilitate execution of kubectl commnds wrapped by Aspirate
