### PR TITLE
41 If publish fails, aspirate still gives success status

### DIFF
--- a/src/Aspirate.Cli/Actions/ActionExecutor.cs
+++ b/src/Aspirate.Cli/Actions/ActionExecutor.cs
@@ -36,6 +36,7 @@ public class ActionExecutor(IAnsiConsole console, IServiceProvider serviceProvid
             catch (ActionCausesExitException exitException)
             {
                 // Do nothing - the action is planned, and will skip the rest of the queue, returning the exit code.
+                console.MarkupLine($"[red bold]({exitException.ExitCode}): Aspirate will now exit.[/]");
                 return exitException.ExitCode;
             }
             catch (Exception)

--- a/src/Aspirate.Cli/Actions/Manifests/ApplyManifestsToClusterAction.cs
+++ b/src/Aspirate.Cli/Actions/Manifests/ApplyManifestsToClusterAction.cs
@@ -15,15 +15,15 @@ public sealed class ApplyManifestsToClusterAction(IKubeCtlService kubeCtlService
             return true;
         }
 
-        var successfullySelectedCluster = await kubeCtlService.SelectKubernetesContextForDeployment();
+        CurrentState.ComputedParameters.ActiveKubernetesContext = await kubeCtlService.SelectKubernetesContextForDeployment();
 
-        if (!successfullySelectedCluster)
+        if (!CurrentState.ComputedParameters.ActiveKubernetesContextIsSet)
         {
             return false;
         }
 
-        await kubeCtlService.ApplyManifests(CurrentState.ComputedParameters.KustomizeManifestPath);
-        Logger.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments successfully applied to cluster [blue]'{kubeCtlService.GetActiveContextName()}'[/]");
+        await kubeCtlService.ApplyManifests(CurrentState.ComputedParameters.ActiveKubernetesContext, CurrentState.ComputedParameters.KustomizeManifestPath);
+        Logger.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments successfully applied to cluster [blue]'{CurrentState.ComputedParameters.ActiveKubernetesContext}'[/]");
 
         return true;
     }

--- a/src/Aspirate.Cli/Actions/Manifests/RemoveManifestsFromClusterAction.cs
+++ b/src/Aspirate.Cli/Actions/Manifests/RemoveManifestsFromClusterAction.cs
@@ -15,15 +15,15 @@ public sealed class RemoveManifestsFromClusterAction(IKubeCtlService kubeCtlServ
             return true;
         }
 
-        var successfullySelectedCluster = await kubeCtlService.SelectKubernetesContextForDeployment();
+        CurrentState.ComputedParameters.ActiveKubernetesContext = await kubeCtlService.SelectKubernetesContextForDeployment();
 
-        if (!successfullySelectedCluster)
+        if (!CurrentState.ComputedParameters.ActiveKubernetesContextIsSet)
         {
             return false;
         }
 
-        await kubeCtlService.RemoveManifests(CurrentState.ComputedParameters.KustomizeManifestPath);
-        Logger.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments removed from cluster [blue]'{kubeCtlService.GetActiveContextName()}'[/]");
+        await kubeCtlService.RemoveManifests(CurrentState.ComputedParameters.ActiveKubernetesContext, CurrentState.ComputedParameters.KustomizeManifestPath);
+        Logger.MarkupLine($"\r\n\t[green]({EmojiLiterals.CheckMark}) Done:[/] Deployments removed from cluster [blue]'{CurrentState.ComputedParameters.ActiveKubernetesContext}'[/]");
 
         return true;
     }

--- a/src/Aspirate.Cli/Services/ContainerCompositionService.cs
+++ b/src/Aspirate.Cli/Services/ContainerCompositionService.cs
@@ -93,7 +93,7 @@ public sealed class ContainerCompositionService(IFileSystem filesystem, IAnsiCon
             throw new ActionCausesExitException(1013);
         }
 
-        return Task.CompletedTask;
+        throw new ActionCausesExitException(9999);
     }
 
     private Task HandleDuplicateFilesInOutput(ArgumentsBuilder argumentsBuilder)
@@ -109,7 +109,7 @@ public sealed class ContainerCompositionService(IFileSystem filesystem, IAnsiCon
             return ExecuteCommand(argumentsBuilder, HandleBuildErrors);
         }
 
-        return Task.CompletedTask;
+        throw new ActionCausesExitException(9999);
     }
 
     private async Task HandleNoDockerRegistryAccess(ArgumentsBuilder argumentsBuilder)

--- a/src/Aspirate.Contracts/Interfaces/IKubeCtlService.cs
+++ b/src/Aspirate.Contracts/Interfaces/IKubeCtlService.cs
@@ -2,8 +2,7 @@ namespace Aspirate.Contracts.Interfaces;
 
 public interface IKubeCtlService
 {
-    Task<bool> SelectKubernetesContextForDeployment();
-    Task<bool> ApplyManifests(string outputFolder);
-    Task<bool> RemoveManifests(string outputFolder);
-    string GetActiveContextName();
+    Task<string?> SelectKubernetesContextForDeployment();
+    Task<bool> ApplyManifests(string context, string outputFolder);
+    Task<bool> RemoveManifests(string context, string outputFolder);
 }

--- a/src/Aspirate.Contracts/Models/State/ComputedParametersState.cs
+++ b/src/Aspirate.Contracts/Models/State/ComputedParametersState.cs
@@ -2,6 +2,7 @@ namespace Aspirate.Contracts.Models.State;
 
 public class ComputedParametersState
 {
+    public string? ActiveKubernetesContext { get; set; }
     public string? AspireManifestPath { get; private set; }
     public string? KustomizeManifestPath { get; private set; }
     public List<string> AspireComponentsToProcess { get; private set; } = [];
@@ -17,6 +18,8 @@ public class ComputedParametersState
         LoadedAspireManifestResources
             .Where(x => x.Value is not UnsupportedResource && AspireComponentsToProcess.Contains(x.Key))
             .ToList();
+
+    public bool ActiveKubernetesContextIsSet => !string.IsNullOrEmpty(ActiveKubernetesContext);
 
     public void SetAspireManifestPath(string path) => AspireManifestPath = path;
 


### PR DESCRIPTION
 Includes propagation of the correct exit code based on the failure action exception raised.
Also unpicks current selected active context from services, and moves it into state.
Fixed #41
