### PR TITLE
Allows skipping the aspire manifest rebuild by passing in -m ./manifest.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,9 +3,22 @@
 
 ### Automate deployment of a .NET Aspire AppHost to a Kubernetes Cluster
 
+<https://github.com/prom3theu5/aspirational-manifests/assets/1518610/319c4e1e-d47f-40e3-a8c3-ddf124b003a2>
+
 ---
 
-### To Install as a global tool
+# Table of Contents
+1. [To Install as a global tool](#to-install-as-a-global-tool)
+2. [ContainerRegistry](#containerregistry)
+3. [Producing Manifests](#producing-manifests)
+4. [Build](#build)
+5. [Apply Manifests](#apply-manifests)
+6. [Remove Manifests](#remove-manifests)
+7. [Non-Interactive Invocation](#non-interactive-invocation)
+8. [Uninstall tool](#uninstall-tool)
+9. [Configuring the Windows Terminal For Unicode and Emoji Support](#configuring-the-windows-terminal-for-unicode-and-emoji-support)
+
+## To Install as a global tool
 
 ```bash
 dotnet tool install -g aspirate --prerelease
@@ -15,15 +28,11 @@ dotnet tool install -g aspirate --prerelease
 
 ---
 
-<https://github.com/prom3theu5/aspirational-manifests/assets/1518610/319c4e1e-d47f-40e3-a8c3-ddf124b003a2>
-
-### Generating Manifests (apply)
-
-#### ContainerRegistry
+## ContainerRegistry
 
 You're csproj files (projects) that will be build as containers **MUST** contain ContainerRegistry as a minimum, or the sdk will raise a CONTAINERS1013 error.
 To get around this - you can either add it as required, or use the 'init' command.
-The init command allows you to bootstrap certain settings for an asire project that Aspir8 will use.
+The init command allows you to bootstrap certain settings for an aspire project that Aspir8 will use.
 
 - ContainerRegistry: setting this means you do not need one in your csproj, and if it isn't found - all builds will use this.
 - ContainerTag - will override the container tag used if not in your csproj - if not specified in settings, will fall-back to latest.
@@ -36,22 +45,39 @@ To use the init command, you simply run:
 aspirate init
 ```
 
-from withinn your AppHost directory - and it'll ask you which settings you'd like to override.
+from within your AppHost directory - and it'll ask you which settings you'd like to override.
 
-#### Produce Manifests
+---
+
+## Producing Manifests
 
 Navigate to your Aspire project's AppHost directory, and run:
 
 ```bash
 aspirate generate
 ```
+This command (by-default) will also build selected projects, and push the containers to the interpolated ContainerRegistry.
+Builds can be skipped by passing the `--skip-build` flag.
 
-Your manifests will be in the AppHost/aspirate-output directory
+Your manifests will be in the AppHost/aspirate-output directory by default.
 
 ---
-> **_INFORMATION:_**  Both the following commands will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
 
-#### Apply Manifests
+## Build
+
+The Build command will build all projects defined in the aspire manifest file, and push the containers to the interpolated ContainerRegistry.
+
+The command is extremely useful for rebuilding and pushing containers to the registry using a simple menu to select the items you want to build.
+
+The command will first create the manifest file, however this can be overridden if you pass in the path to an existing manifest file using the `--aspire-manifest` or `-m` flag and supplying the path.
+
+```bash
+aspirate build
+```
+
+---
+
+## Apply Manifests
 
 To apply the manifests to your cluster, run:
 
@@ -59,7 +85,11 @@ To apply the manifests to your cluster, run:
 aspirate apply
 ```
 
-#### Remove Manifests
+Aspirate will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
+
+---
+
+## Remove Manifests
 
 To remove the manifests from your cluster, run:
 
@@ -67,9 +97,21 @@ To remove the manifests from your cluster, run:
 aspirate destroy
 ```
 
+Aspirate will first ask you which context they would like you to operate on, and will confirm first that you wish to act.
+
 ---
 
-### Uninstall tool
+## Non-Interactive Invocation
+All commands can be invoked non-interactively by passing the `--non-interactive` flag.
+
+This will cause the tool to use the default context and not prompt for confirmation.
+
+When using this flag, all configuration arguments must be passed on the command line.
+
+---
+
+## Uninstall tool
+Aspirate can be uninstalled as a global tool by running:
 
 ```bash
 dotnet tool uninstall -g aspirate
@@ -77,7 +119,7 @@ dotnet tool uninstall -g aspirate
 
 ---
 
-### Configuring the Windows Terminal For Unicode and Emoji Support
+## Configuring the Windows Terminal For Unicode and Emoji Support
 
 Windows Terminal supports Unicode and Emoji. However, the shells such as Powershell and cmd.exe do not.
 For the difference between the two,

--- a/src/Aspirate.Cli/Actions/Manifests/GenerateAspireManifestAction.cs
+++ b/src/Aspirate.Cli/Actions/Manifests/GenerateAspireManifestAction.cs
@@ -8,20 +8,28 @@ public sealed class GenerateAspireManifestAction(
 
     public override async Task<bool> ExecuteAsync()
     {
+        if (!string.IsNullOrEmpty(CurrentState.AspireManifest))
+        {
+            Logger.MarkupLine($"\r\n[bold]Aspire Manifest supplied at path: [blue]{CurrentState.AspireManifest}[/].[/]");
+            Logger.MarkupLine("[bold]Skipping Aspire Manifest generation.[/]");
+            Logger.WriteLine();
+            return true;
+        }
+
         Logger.MarkupLine("\r\n[bold]Generating Aspire Manifest for supplied App Host:[/]\r\n");
 
         var result = await manifestCompositionService.BuildManifestForProject(CurrentState.ProjectPath);
 
         if (result.Success)
         {
-            CurrentState.ProjectManifest = result.FullPath;
+            CurrentState.AspireManifest = result.FullPath;
 
-            Logger.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Created Aspire Manifest At Path: [blue]{CurrentState.ProjectManifest}[/]");
+            Logger.MarkupLine($"\t[green]({EmojiLiterals.CheckMark}) Done: [/] Created Aspire Manifest At Path: [blue]{CurrentState.AspireManifest}[/]");
 
             return true;
         }
 
-        Logger.MarkupLine($"[red]Failed to generate Aspire Manifest at: {CurrentState.ProjectManifest}[/]");
+        Logger.MarkupLine($"[red]Failed to generate Aspire Manifest at: {CurrentState.AspireManifest}[/]");
         throw new InvalidOperationException("Failed to generate Aspire Manifest.");
     }
 }

--- a/src/Aspirate.Cli/Actions/Manifests/LoadAspireManifestAction.cs
+++ b/src/Aspirate.Cli/Actions/Manifests/LoadAspireManifestAction.cs
@@ -8,7 +8,7 @@ public class LoadAspireManifestAction(
 
     public override Task<bool> ExecuteAsync()
     {
-        var aspireManifest = manifestFileParserService.LoadAndParseAspireManifest(CurrentState.ProjectManifest);
+        var aspireManifest = manifestFileParserService.LoadAndParseAspireManifest(CurrentState.AspireManifest);
         CurrentState.LoadedAspireManifestResources = aspireManifest;
 
         var componentsToProcess = SelectManifestItemsToProcess();
@@ -39,7 +39,7 @@ public class LoadAspireManifestAction(
 
     public override void ValidateNonInteractiveState()
     {
-        if (string.IsNullOrEmpty(CurrentState.ProjectManifest))
+        if (string.IsNullOrEmpty(CurrentState.AspireManifest))
         {
             NonInteractiveValidationFailed("No Aspire Manifest file was supplied.");
         }

--- a/src/Aspirate.Cli/AspirateCli.cs
+++ b/src/Aspirate.Cli/AspirateCli.cs
@@ -4,10 +4,15 @@ internal class AspirateCli : RootCommand
 {
     internal static void WelcomeMessage()
     {
-        AnsiConsole.WriteLine();
-        AnsiConsole.Write(new FigletText("Aspir8").Color(Color.HotPink));
-        AnsiConsole.MarkupLine("[bold lime]Automate deployment of a .NET Aspire AppHost to a Kubernetes Cluster[/]");
-        AnsiConsole.WriteLine();
+        var skipLogo = Environment.GetEnvironmentVariable("ASPIRATE_NO_LOGO");
+
+        if (string.IsNullOrEmpty(skipLogo))
+        {
+            AnsiConsole.WriteLine();
+            AnsiConsole.Write(new FigletText("Aspir8").Color(Color.HotPink));
+            AnsiConsole.MarkupLine("[bold lime]Automate deployment of a .NET Aspire AppHost to a Kubernetes Cluster[/]");
+            AnsiConsole.WriteLine();
+        }
     }
 
     public AspirateCli()

--- a/src/Aspirate.Cli/Commands/Build/BuildCommand.cs
+++ b/src/Aspirate.Cli/Commands/Build/BuildCommand.cs
@@ -5,6 +5,7 @@ public sealed class BuildCommand : BaseCommand<BuildOptions, BuildCommandHandler
     public BuildCommand() : base("build", "Builds and pushes containers")
     {
        AddOption(SharedOptions.AspireProjectPath);
+       AddOption(SharedOptions.AspireManifest);
        AddOption(SharedOptions.NonInteractive);
     }
 }

--- a/src/Aspirate.Cli/Commands/Build/BuildOptions.cs
+++ b/src/Aspirate.Cli/Commands/Build/BuildOptions.cs
@@ -3,5 +3,6 @@ namespace Aspirate.Cli.Commands.Build;
 public sealed class BuildOptions : ICommandOptions
 {
     public string ProjectPath { get; set; } = AspirateLiterals.DefaultAspireProjectPath;
+    public string? AspireManifest { get; set; }
     public bool NonInteractive { get; set; } = false;
 }

--- a/src/Aspirate.Cli/Commands/Generate/GenerateCommand.cs
+++ b/src/Aspirate.Cli/Commands/Generate/GenerateCommand.cs
@@ -5,6 +5,7 @@ public sealed class GenerateCommand : BaseCommand<GenerateOptions, GenerateComma
     public GenerateCommand() : base("generate", "Builds, pushes containers, generates aspire manifest and kustomize manifests.")
     {
        AddOption(SharedOptions.AspireProjectPath);
+       AddOption(SharedOptions.AspireManifest);
        AddOption(SharedOptions.OutputPath);
        AddOption(SharedOptions.NonInteractive);
        AddOption(SharedOptions.SkipBuild);

--- a/src/Aspirate.Cli/Commands/Generate/GenerateOptions.cs
+++ b/src/Aspirate.Cli/Commands/Generate/GenerateOptions.cs
@@ -3,6 +3,7 @@ namespace Aspirate.Cli.Commands.Generate;
 public sealed class GenerateOptions : ICommandOptions
 {
     public string ProjectPath { get; set; } = AspirateLiterals.DefaultAspireProjectPath;
+    public string? AspireManifest { get; set; }
     public string OutputPath { get; set; } = AspirateLiterals.DefaultOutputPath;
 
     public bool SkipBuild { get; set; } = false;

--- a/src/Aspirate.Cli/Commands/SharedOptions.cs
+++ b/src/Aspirate.Cli/Commands/SharedOptions.cs
@@ -30,6 +30,13 @@ public static class SharedOptions
         IsRequired = false,
     };
 
+    public static Option<string> AspireManifest => new(new[] { "-m", "--aspire-manifest" })
+    {
+        Description = "The aspire manifest file to use",
+        Arity = ArgumentArity.ExactlyOne,
+        IsRequired = false,
+    };
+
     public static Option<bool> SkipBuild => new(new[] { "--skip-build" })
     {
         Description = "Skips build and Push of containers",

--- a/src/Aspirate.Shared/Models/State/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/State/AspirateState.cs
@@ -3,7 +3,7 @@ namespace Aspirate.Shared.Models.State;
 public class AspirateState
 {
     public string? ProjectPath { get; set; }
-    public string? ProjectManifest { get; set; }
+    public string? AspireManifest { get; set; }
     public string? InputPath { get; set; }
     public string? OutputPath { get; set; }
     public string? ContainerRegistry { get; set; }


### PR DESCRIPTION
Very useful if you just want to rebuild and push containers as it immediately shows the menu of items within the manifest, for you to select items from
