### PR TITLE
Add option to disable secret generation

### DIFF
--- a/src/Aspirate.Cli/Properties/launchSettings.json
+++ b/src/Aspirate.Cli/Properties/launchSettings.json
@@ -14,7 +14,7 @@
     },
     "generate": {
       "commandName": "Project",
-      "commandLineArgs": "generate -m ./manifest.json",
+      "commandLineArgs": "generate",
       "workingDirectory": "$(ProjectDir)/../../../aspire/samples/eShopLite/AppHost",
       "hotReloadEnabled": false
     },

--- a/src/Aspirate.Cli/Templates/redis.hbs
+++ b/src/Aspirate.Cli/Templates/redis.hbs
@@ -15,7 +15,7 @@ spec:
     spec:
       containers:
         - name: redis
-          image: mcr.microsoft.com/oss/bitnami/redis:6.0.8
+          image: bitnami/redis:latest
           env:
             - name: ALLOW_EMPTY_PASSWORD
               value: "yes"

--- a/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
@@ -66,6 +66,11 @@ public sealed class ApplyManifestsToClusterAction(
 
     private async Task WriteSecretsOutToTempFiles(List<string> files)
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         if (secretProvider is PasswordSecretProvider passwordSecretProvider)
         {
             Logger.MarkupLine($"\r\n[green]({EmojiLiterals.CheckMark}) Done:[/] Decrypting secrets from [blue]{CurrentState.InputPath}[/]");
@@ -92,6 +97,11 @@ public sealed class ApplyManifestsToClusterAction(
 
     private void CleanupSecretEnvFiles(IEnumerable<string> secretFiles)
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         foreach (var secretFile in secretFiles.Where(secretFile => fileSystem.File.Exists(secretFile)))
         {
             fileSystem.File.Delete(secretFile);

--- a/src/Aspirate.Commands/Actions/Manifests/GenerateKustomizeManifestsAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateKustomizeManifestsAction.cs
@@ -48,7 +48,7 @@ public sealed class GenerateKustomizeManifestsAction(
             return;
         }
 
-        var success = await handler.CreateManifests(resource, CurrentState.OutputPath, CurrentState.ImagePullPolicy, CurrentState.TemplatePath);
+        var success = await handler.CreateManifests(resource, CurrentState.OutputPath, CurrentState.ImagePullPolicy, CurrentState.TemplatePath, CurrentState.DisableSecrets);
 
         if (success && !CurrentState.IsDatabase(resource.Value))
         {

--- a/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
@@ -56,6 +56,11 @@ public sealed class RemoveManifestsFromClusterAction(
 
     private void CreateEmptySecretFiles(List<string> files)
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         if (secretProvider is PasswordSecretProvider passwordSecretProvider)
         {
             passwordSecretProvider.LoadState(CurrentState.InputPath);
@@ -87,6 +92,11 @@ public sealed class RemoveManifestsFromClusterAction(
 
     private void CleanupSecretEnvFiles(IEnumerable<string> secretFiles)
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         foreach (var secretFile in secretFiles.Where(secretFile => fileSystem.File.Exists(secretFile)))
         {
             fileSystem.File.Delete(secretFile);

--- a/src/Aspirate.Commands/Actions/Secrets/LoadSecretsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/LoadSecretsAction.cs
@@ -6,6 +6,11 @@ public class LoadSecretsAction(
 {
     public override Task<bool> ExecuteAsync()
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return Task.FromResult(true);
+        }
+
         if (!secretProvider.SecretStateExists(CurrentState.InputPath))
         {
             return Task.FromResult(true);
@@ -52,6 +57,11 @@ public class LoadSecretsAction(
 
     public override void ValidateNonInteractiveState()
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         if (!secretProvider.SecretStateExists(CurrentState.InputPath))
         {
             return;

--- a/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
@@ -6,6 +6,11 @@ public class PopulateInputsAction(
 {
     public override Task<bool> ExecuteAsync()
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return Task.FromResult(true);
+        }
+
         var componentsWithInputs = CurrentState.AllSelectedSupportedComponents.Where(x => x.Value is IResourceWithInput).ToArray();
 
         if (componentsWithInputs.Length == 0)
@@ -121,6 +126,11 @@ public class PopulateInputsAction(
 
     public override void ValidateNonInteractiveState()
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return;
+        }
+
         var componentsWithInputs = CurrentState.AllSelectedSupportedComponents.Where(x => x.Value is IResourceWithInput).ToArray();
 
         var manualInputs = componentsWithInputs

--- a/src/Aspirate.Commands/Actions/Secrets/SaveSecretsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/SaveSecretsAction.cs
@@ -14,6 +14,11 @@ public class SaveSecretsAction(
 
     public override Task<bool> ExecuteAsync()
     {
+        if (CurrentState.DisableSecrets)
+        {
+            return Task.FromResult(true);
+        }
+
         if (!ProtectionStrategies.CheckForProtectableSecrets(CurrentState.AllSelectedSupportedComponents))
         {
             console.MarkupLine("No secrets to protect in any [blue]selected components[/]");

--- a/src/Aspirate.Commands/AspirateState.cs
+++ b/src/Aspirate.Commands/AspirateState.cs
@@ -42,6 +42,9 @@ public class AspirateState :
     [JsonPropertyName("nonInteractive")]
     public bool NonInteractive { get; set; }
 
+    [JsonPropertyName("disableSecrets")]
+    public bool DisableSecrets { get; set; }
+
     [JsonPropertyName("secretProvider")]
     public ProviderType SecretProvider { get; set; }
 

--- a/src/Aspirate.Commands/Commands/BaseCommand.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommand.cs
@@ -10,6 +10,7 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
     {
         AddOption(NonInteractive);
         AddOption(SecretProvider);
+        AddOption(DisableSecrets);
         Handler = CommandHandler.Create<TOptions, IServiceCollection>(ConstructCommand);
     }
 
@@ -37,5 +38,12 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
         Arity = ArgumentArity.ExactlyOne,
         IsRequired = false,
         IsHidden = true,
+    };
+
+    private static Option<bool> DisableSecrets => new(new[] { "--disable-secrets" })
+    {
+        Description = "Disables Secret Support",
+        Arity = ArgumentArity.ZeroOrOne,
+        IsRequired = false,
     };
 }

--- a/src/Aspirate.Commands/Commands/BaseCommandOptions.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommandOptions.cs
@@ -5,4 +5,6 @@ public abstract class BaseCommandOptions : ICommandOptions
 {
     public bool NonInteractive { get; set; } = false;
     public ProviderType SecretProvider { get; set; } = ProviderType.Password;
+
+    public bool DisableSecrets { get; set; } = false;
 }

--- a/src/Aspirate.Processors/BaseProcessor.cs
+++ b/src/Aspirate.Processors/BaseProcessor.cs
@@ -162,8 +162,11 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
     /// <param name="outputPath">The path where the manifests will be created.</param>
     /// <param name="imagePullPolicy">The image pull policy for the resource.</param>
     /// <param name="templatePath">Optional. The path to the template used for creating the manifests.</param>
+    /// <param name="disableSecrets">Passing this will disable all secret generation.</param>
     /// <returns>A task that represents the asynchronous operation. The task result is a boolean indicating if the manifests were created successfully.</returns>
-    public virtual Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? templatePath = null)
+    public virtual Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null,
+        bool? disableSecrets = false)
     {
         _console.LogCreateManifestNotOverridden(GetType().Name);
 

--- a/src/Aspirate.Processors/Postgresql/PostgresDatabaseProcessor.cs
+++ b/src/Aspirate.Processors/Postgresql/PostgresDatabaseProcessor.cs
@@ -12,7 +12,8 @@ public class PostgresDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole cons
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<PostgresDatabase>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? templatePath = null) =>
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null, bool? disableSecrets = false) =>
         // Do nothing for databases, they are there for configuration.
         Task.FromResult(true);
 }

--- a/src/Aspirate.Processors/Postgresql/PostgresServerProcessor.cs
+++ b/src/Aspirate.Processors/Postgresql/PostgresServerProcessor.cs
@@ -17,7 +17,8 @@ public class PostgresServerProcessor(IFileSystem fileSystem, IAnsiConsole consol
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<PostgresServer>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? templatePath = null)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null, bool? disableSecrets = false)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 

--- a/src/Aspirate.Processors/RabbitMQ/RabbitMQProcessor.cs
+++ b/src/Aspirate.Processors/RabbitMQ/RabbitMQProcessor.cs
@@ -19,7 +19,8 @@ public class RabbitMqProcessor(IFileSystem fileSystem, IAnsiConsole console) : B
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<AspireRabbit>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? templatePath = null)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null, bool? disableSecrets = false)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 

--- a/src/Aspirate.Processors/Redis/RedisProcessor.cs
+++ b/src/Aspirate.Processors/Redis/RedisProcessor.cs
@@ -19,7 +19,8 @@ public class RedisProcessor(IFileSystem fileSystem, IAnsiConsole console) : Base
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>
         JsonSerializer.Deserialize<AspireRedis>(ref reader);
 
-    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? templatePath)
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath, bool? disableSecrets = false)
     {
         var resourceOutputPath = Path.Combine(outputPath, resource.Key);
 

--- a/src/Aspirate.Shared/Processors/IProcessor.cs
+++ b/src/Aspirate.Shared/Processors/IProcessor.cs
@@ -24,5 +24,10 @@ public interface IProcessor
     /// <summary>
     /// Produces the output manifest file.
     /// </summary>
-    Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy, string? aspirateSettings = null);
+    Task<bool> CreateManifests(
+        KeyValuePair<string, Resource> resource,
+        string outputPath,
+        string imagePullPolicy,
+        string? aspirateSettings = null,
+        bool? disableSecrets = false);
 }


### PR DESCRIPTION
This update introduces the ability to disable secret generation across the Aspirate Project. A "DisableSecrets" option is added, which when set to true, turns off all secret generations. This is particularly useful when secret generation is unnecessary or poses unnecessary overhead. The update also changes the Docker image for Redis to use the latest version, instead of a specific version.
