### PR TITLE
Create directory if not existing in BaseSecretProvider

### DIFF
--- a/src/Aspirate.Secrets/BaseSecretProvider.cs
+++ b/src/Aspirate.Secrets/BaseSecretProvider.cs
@@ -60,6 +60,12 @@ public abstract class BaseSecretProvider<TState>(IFileSystem fileSystem) : ISecr
 
         var state = JsonSerializer.Serialize(State, _serializerOptions);
         var outputFile = fileSystem.Path.Combine(path, AspirateSecretLiterals.SecretsStateFile);
+
+        if (!fileSystem.Directory.Exists(path))
+        {
+            fileSystem.Directory.CreateDirectory(path);
+        }
+
         fileSystem.File.WriteAllText(outputFile, state);
     }
 


### PR DESCRIPTION
This update makes sure a directory is created in the file system if it does not exist. This change was made in the BaseSecretProvider class and ensures that the file system path is ready to write, preventing failures due to a non-existing directory.
