### PR TITLE
Add support for SQL Server manifests and templates

### DIFF
--- a/src/Aspirate.Cli/Aspirate.Cli.csproj
+++ b/src/Aspirate.Cli/Aspirate.Cli.csproj
@@ -42,6 +42,9 @@
 
   <ItemGroup>
     <None Include="nuget-icon.png" Pack="true" Visible="false" PackagePath="" />
+    <None Update="Templates\sqlserver.hbs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspirate.Cli/Templates/sqlserver.hbs
+++ b/src/Aspirate.Cli/Templates/sqlserver.hbs
@@ -1,0 +1,62 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: sqlserver-configuration
+  labels:
+    app: sqlserver
+data:
+  ACCEPT_EULA: "Y"
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: sqlserver-secrets
+labels:
+  app: sqlserver
+type: Opaque
+data:
+  MSSQL_SA_PASSWORD: {{saPassword}}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: sqlserver-statefulset
+  labels:
+    app: sqlserver
+spec:
+  serviceName: "sqlserver"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: sqlserver
+  template:
+    metadata:
+      labels:
+        app: sqlserver
+    spec:
+      containers:
+        - name: sqlserver
+          image: mcr.microsoft.com/mssql/server:2022-latest
+          envFrom:
+            - configMapRef:
+                name: sqlserver-configuration
+            - secretRef:
+            name: sqlserver-secrets
+          ports:
+            - containerPort: 1433
+              name: sqlserverdb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: sqlserver-service
+  labels:
+    app: sqlserver
+spec:
+  type: ClusterIP
+  ports:
+    - port: 1433
+      name: sqlserver
+  selector:
+    app: sqlserver

--- a/src/Aspirate.Commands/AspirateState.cs
+++ b/src/Aspirate.Commands/AspirateState.cs
@@ -1,3 +1,5 @@
+using Aspirate.Shared.Models.AspireManifests.Components.V1;
+
 namespace Aspirate.Commands;
 
 public class AspirateState :
@@ -104,5 +106,5 @@ public class AspirateState :
         FinalResources.Add(key, resource);
 
     public bool IsDatabase(Resource resource) =>
-        resource is PostgresDatabase;
+        resource is PostgresDatabase or SqlServerDatabase;
 }

--- a/src/Aspirate.Processors/BaseProcessor.cs
+++ b/src/Aspirate.Processors/BaseProcessor.cs
@@ -40,6 +40,7 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
         [AspireLiterals.PostgresDatabase] = (resourceName, resources) => $"host=postgres-service;database={resourceName};username=postgres;password=postgres;",
         [AspireLiterals.Container] = (resourceName, resources) => ReplaceConnectionStringPlaceholders(resources[resourceName] as AspireContainer, resources),
         [AspireLiterals.RabbitMq] = (resourceName, resources) => "amqp://guest:guest@rabbitmq-service:5672",
+        [AspireLiterals.SqlServer] = (resourceName, resources) => $"Server=sqlserver-service,1433;User ID=sa;Password={resources[resourceName].Env["SaPassword"]};TrustServerCertificate=true;",
     };
 
     /// <summary>
@@ -57,7 +58,7 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
     /// </summary>
     private readonly List<string> _protectedEnvVars =
     [
-        "ConnectionString",
+        ProtectableLiterals.ConnectionString,
     ];
 
     /// <summary>
@@ -69,6 +70,7 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
         [TemplateLiterals.ServiceType] = $"{TemplateLiterals.ServiceType}.hbs",
         [TemplateLiterals.ComponentKustomizeType] = $"{TemplateLiterals.ComponentKustomizeType}.hbs",
         [TemplateLiterals.RedisType] = $"{TemplateLiterals.RedisType}.hbs",
+        [TemplateLiterals.SqlServerType] = $"{TemplateLiterals.SqlServerType}.hbs",
         [TemplateLiterals.RabbitMqType] = $"{TemplateLiterals.RabbitMqType}.hbs",
         [TemplateLiterals.PostgresServerType] = $"{TemplateLiterals.PostgresServerType}.hbs",
     };

--- a/src/Aspirate.Processors/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Processors/Extensions/ServiceCollectionExtensions.cs
@@ -18,6 +18,8 @@ public static class ServiceCollectionExtensions
             .RegisterProcessor<RedisProcessor>(AspireLiterals.Redis)
             .RegisterProcessor<RabbitMqProcessor>(AspireLiterals.RabbitMq)
             .RegisterProcessor<ContainerProcessor>(AspireLiterals.Container)
+            .RegisterProcessor<SqlServerProcessor>(AspireLiterals.SqlServer)
+            .RegisterProcessor<SqlServerDatabaseProcessor>(AspireLiterals.SqlServerDatabase)
             .RegisterProcessor<FinalProcessor>(AspireLiterals.Final);
 
     /// <summary>

--- a/src/Aspirate.Processors/GlobalUsings.cs
+++ b/src/Aspirate.Processors/GlobalUsings.cs
@@ -9,6 +9,8 @@ global using Aspirate.Processors.Postgresql;
 global using Aspirate.Processors.Project;
 global using Aspirate.Processors.RabbitMQ;
 global using Aspirate.Processors.Redis;
+global using Aspirate.Processors.SqlServer;
+global using Aspirate.Secrets.Literals;
 global using Aspirate.Secrets.Services;
 global using Aspirate.Services.Interfaces;
 global using Aspirate.Shared.Extensions;

--- a/src/Aspirate.Processors/SqlServer/SqlServerDatabaseProcessor.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerDatabaseProcessor.cs
@@ -1,0 +1,21 @@
+using Aspirate.Shared.Models.AspireManifests.Components.V1;
+
+namespace Aspirate.Processors.SqlServer;
+
+/// <summary>
+/// Handles producing the Postgres component as Kustomize manifest.
+/// </summary>
+public class SqlServerDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole console) : BaseProcessor<SqlServerDatabaseTemplateData>(fileSystem, console)
+{
+    /// <inheritdoc />
+    public override string ResourceType => AspireLiterals.SqlServerDatabase;
+
+    /// <inheritdoc />
+    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
+        JsonSerializer.Deserialize<SqlServerDatabase>(ref reader);
+
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null, bool? disableSecrets = false) =>
+        // Do nothing for databases, they are there for configuration.
+        Task.FromResult(true);
+}

--- a/src/Aspirate.Processors/SqlServer/SqlServerDatabaseTemplateData.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerDatabaseTemplateData.cs
@@ -1,0 +1,8 @@
+namespace Aspirate.Processors.SqlServer;
+
+public sealed class SqlServerDatabaseTemplateData(
+    string name,
+    Dictionary<string, string> env,
+    IReadOnlyCollection<string> manifests,
+    bool isService)
+    : BaseTemplateData(null, null, null, manifests, false);

--- a/src/Aspirate.Processors/SqlServer/SqlServerProcessor.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerProcessor.cs
@@ -1,0 +1,48 @@
+namespace Aspirate.Processors.SqlServer;
+
+public sealed class SqlServerProcessor(IFileSystem fileSystem, IAnsiConsole console, IPasswordGenerator passwordGenerator) : BaseProcessor<SqlServerTemplateData>(fileSystem, console)
+{
+    private readonly IReadOnlyCollection<string> _manifests =
+    [
+        $"{TemplateLiterals.SqlServerType}.yml",
+    ];
+
+    /// <inheritdoc />
+    public override string ResourceType => AspireLiterals.SqlServer;
+
+    /// <inheritdoc />
+    public override Resource? Deserialize(ref Utf8JsonReader reader)
+    {
+        var resource = JsonSerializer.Deserialize<Shared.Models.AspireManifests.Components.V1.SqlServer>(ref reader);
+        resource.Env = new()
+        {
+            ["SaPassword"] = passwordGenerator.Generate().ToBase64(),
+        };
+
+        return resource;
+    }
+
+    public override Task<bool> CreateManifests(
+        KeyValuePair<string, Resource> resource,
+        string outputPath,
+        string imagePullPolicy,
+        string? templatePath,
+        bool? disableSecrets = false)
+    {
+        var resourceOutputPath = Path.Combine(outputPath, resource.Key);
+
+        EnsureOutputDirectoryExistsAndIsClean(resourceOutputPath);
+
+        var data = new SqlServerTemplateData(_manifests)
+        {
+            SaPassword = resource.Value.Env["SaPassword"],
+        };
+
+        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.SqlServerType}.yml", TemplateLiterals.SqlServerType, data, templatePath);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, templatePath);
+
+        LogCompletion(resourceOutputPath);
+
+        return Task.FromResult(true);
+    }
+}

--- a/src/Aspirate.Processors/SqlServer/SqlServerTemplateData.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerTemplateData.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Processors.SqlServer;
+
+public sealed class SqlServerTemplateData(IReadOnlyCollection<string> manifests)
+    : BaseTemplateData(null, null, null, manifests, false)
+{
+    public required string SaPassword { get; set; }
+}

--- a/src/Aspirate.Shared/Extensions/StringExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/StringExtensions.cs
@@ -1,0 +1,10 @@
+namespace Aspirate.Shared.Extensions;
+
+public static class StringExtensions
+{
+    public static string ToBase64(this string value)
+    {
+        var plainTextBytes = Encoding.UTF8.GetBytes(value);
+        return Convert.ToBase64String(plainTextBytes);
+    }
+}

--- a/src/Aspirate.Shared/GlobalUsings.cs
+++ b/src/Aspirate.Shared/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO.Abstractions;
+global using System.Text;
 global using System.Text.Json;
 global using System.Text.Json.Serialization;
 

--- a/src/Aspirate.Shared/Literals/AspireLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireLiterals.cs
@@ -10,6 +10,8 @@ public static class AspireLiterals
     public const string Container = "container.v0";
     public const string Redis = "redis.v0";
     public const string RabbitMq = "rabbitmq.server.v0";
+    public const string SqlServer = "sqlserver.server.v1";
+    public const string SqlServerDatabase = "sqlserver.database.v1";
     public const string Final = "final";
     public const string DefaultManifestFile = "manifest.json";
     public const string ManifestPublisherArgument = "manifest";

--- a/src/Aspirate.Shared/Literals/TemplateLiterals.cs
+++ b/src/Aspirate.Shared/Literals/TemplateLiterals.cs
@@ -7,6 +7,7 @@ public class TemplateLiterals
     public const string DeploymentType = "deployment";
     public const string ServiceType = "service";
     public const string RedisType = "redis";
+    public const string SqlServerType = "sqlserver";
     public const string RabbitMqType = "rabbitmq";
     public const string PostgresServerType = "postgres-server";
     public const string ComponentKustomizeType = "kustomization";

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V1/SqlServer.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V1/SqlServer.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.V1;
+
+/// <summary>
+/// A SqlServer component for version 1 of Aspire.
+/// </summary>
+[ExcludeFromCodeCoverage]
+public class SqlServer : Resource;

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V1/SqlServerDatabase.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V1/SqlServerDatabase.cs
@@ -1,0 +1,11 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.V1;
+
+[ExcludeFromCodeCoverage]
+public class SqlServerDatabase : Resource
+{
+    /// <summary>
+    /// The parent server of the database.
+    /// </summary>
+    [JsonPropertyName("parent")]
+    public string? Parent { get; set; }
+}

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/LoadAspireManifestActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/LoadAspireManifestActionTests.cs
@@ -23,7 +23,7 @@ public class LoadAspireManifestActionTests : BaseActionTests<LoadAspireManifestA
         // Assert
         result.Should().BeTrue();
         state.SelectedProjectComponents.Should().HaveCount(2);
-        state.LoadedAspireManifestResources.Keys.Count.Should().Be(6);
+        state.LoadedAspireManifestResources.Keys.Count.Should().Be(8);
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class LoadAspireManifestActionTests : BaseActionTests<LoadAspireManifestA
         // Assert
         result.Should().BeTrue();
         state.SelectedProjectComponents.Should().HaveCount(2);
-        state.LoadedAspireManifestResources.Keys.Count.Should().Be(6);
+        state.LoadedAspireManifestResources.Keys.Count.Should().Be(8);
     }
 }

--- a/tests/Aspirate.Tests/GlobalUsings.cs
+++ b/tests/Aspirate.Tests/GlobalUsings.cs
@@ -23,6 +23,7 @@ global using Aspirate.Shared.Models.Aspirate;
 global using Aspirate.Shared.Models.AspireManifests;
 global using Aspirate.Shared.Models.AspireManifests.Components;
 global using Aspirate.Shared.Models.AspireManifests.Components.V0;
+global using Aspirate.Shared.Models.AspireManifests.Components.V1;
 global using Aspirate.Shared.Models.AspireManifests.Interfaces;
 global using Aspirate.Shared.Models.MsBuild;
 global using FluentAssertions;

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -134,8 +134,11 @@ public class ManifestFileParserServiceTest
         var result = state.LoadedAspireManifestResources;
 
         // Assert
-        result.Should().HaveCount(6);
+        result.Should().HaveCount(8);
         result["postgres"].Should().BeOfType<PostgresServer>();
+        result["sqlserver"].Should().BeOfType<SqlServer>();
+        result["sqlserver"].Env["SaPassword"].Should().NotBeNull().And.NotBeEmpty();
+        result["sqldb"].Should().BeOfType<SqlServerDatabase>();
         result["catalogdb"].Should().BeOfType<PostgresDatabase>();
         result["basketcache"].Should().BeOfType<Redis>();
         result["catalogservice"].Should().BeOfType<Project>();

--- a/tests/Aspirate.Tests/TestData/manifest.json
+++ b/tests/Aspirate.Tests/TestData/manifest.json
@@ -3,9 +3,16 @@
       "postgres": {
         "type": "postgres.server.v0"
       },
+      "sqlserver": {
+        "type": "sqlserver.server.v1"
+      },
       "catalogdb": {
         "type": "postgres.database.v0",
         "parent": "postgres"
+      },
+      "sqldb": {
+        "type": "sqlserver.database.v1",
+        "parent": "sqlserver"
       },
       "basketcache": {
         "type": "redis.v0"


### PR DESCRIPTION
This update includes the support for SQL Server related versions, including the addition of new classes and updating existing classes to accommodate SQL Server related operations. Additionally, new tests were updated to include SQL Server cases.
