### PR TITLE
70 'Object reference not set to an instance of an object' while deploying

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/ApplyManifestsToClusterAction.cs
@@ -71,8 +71,18 @@ public sealed class ApplyManifestsToClusterAction(
             return;
         }
 
+        if (!secretProvider.SecretStateExists(CurrentState.InputPath))
+        {
+            return;
+        }
+
         if (secretProvider is PasswordSecretProvider passwordSecretProvider)
         {
+            if (passwordSecretProvider.State?.Secrets is null || passwordSecretProvider.State.Secrets.Count == 0)
+            {
+                return;
+            }
+
             Logger.MarkupLine($"\r\n[green]({EmojiLiterals.CheckMark}) Done:[/] Decrypting secrets from [blue]{CurrentState.InputPath}[/]");
 
             foreach (var resourceSecrets in passwordSecretProvider.State.Secrets.Where(x=>x.Value.Keys.Count > 0))

--- a/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/RemoveManifestsFromClusterAction.cs
@@ -61,9 +61,19 @@ public sealed class RemoveManifestsFromClusterAction(
             return;
         }
 
+        if (!secretProvider.SecretStateExists(CurrentState.InputPath))
+        {
+            return;
+        }
+
         if (secretProvider is PasswordSecretProvider passwordSecretProvider)
         {
             passwordSecretProvider.LoadState(CurrentState.InputPath);
+
+            if (passwordSecretProvider.State?.Secrets is null || passwordSecretProvider.State.Secrets.Count == 0)
+            {
+                return;
+            }
 
             foreach (var resourceSecrets in passwordSecretProvider.State.Secrets.Where(x=>x.Value.Keys.Count > 0))
             {

--- a/src/Aspirate.Processors/Dockerfile/DockerfileTemplateData.cs
+++ b/src/Aspirate.Processors/Dockerfile/DockerfileTemplateData.cs
@@ -6,11 +6,13 @@ public class DockerfileTemplateData(
     Dictionary<string, string>? env,
     Dictionary<string, string>? secrets,
     List<Ports> ports,
-    IReadOnlyCollection<string> manifests)
+    IReadOnlyCollection<string> manifests,
+    string imagePullPolicy)
     : BaseTemplateData(name, env, secrets, manifests)
 {
     public string ContainerImage { get; set; } = containerImage;
     public bool IsDockerfile { get; set; } = true;
+    public string ImagePullPolicy { get; set; } = imagePullPolicy;
     public List<Ports> Ports { get; set; } = ports;
     public bool HasPorts => Ports.Any();
 

--- a/src/Aspirate.Processors/GlobalUsings.cs
+++ b/src/Aspirate.Processors/GlobalUsings.cs
@@ -1,5 +1,6 @@
 global using System.Diagnostics.CodeAnalysis;
 global using System.IO.Abstractions;
+global using System.Text;
 global using System.Text.Json;
 global using System.Text.RegularExpressions;
 global using Aspirate.Processors.Container;

--- a/src/Aspirate.Services/Interfaces/IContainerCompositionService.cs
+++ b/src/Aspirate.Services/Interfaces/IContainerCompositionService.cs
@@ -35,5 +35,5 @@ public interface IContainerCompositionService
     /// It then pushes the created image to the specified registry.
     /// The nonInteractive parameter can be set to true to suppress any interactive prompts during the build process.
     /// </remarks>
-    Task<bool> BuildAndPushContainerForDockerfile(Dockerfile dockerfile, string builder, string imageName, string registry, bool nonInteractive);
+    Task<bool> BuildAndPushContainerForDockerfile(Dockerfile dockerfile, string builder, string imageName, string? registry, bool nonInteractive);
 }


### PR DESCRIPTION
The commit adds a check for secret state before processing secretProvider in the RemoveManifestsFromClusterAction and ApplyManifestsToClusterAction classes. Also, it makes the Docker container registry optional across different classes, appending the registry to the image tag only when provided. Finally, an imagePullPolicy was included in Dockerfile processors to manage Docker image pulling more effectively.
This fixes #70
