### PR TITLE
Add MySQL support to Aspirate tool

### DIFF
--- a/src/Aspirate.Cli/Aspirate.Cli.csproj
+++ b/src/Aspirate.Cli/Aspirate.Cli.csproj
@@ -45,6 +45,9 @@
     <None Update="Templates\sqlserver.hbs">
       <CopyToOutputDirectory>Always</CopyToOutputDirectory>
     </None>
+    <None Update="Templates\mysql.hbs">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </None>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Aspirate.Cli/Templates/mysql.hbs
+++ b/src/Aspirate.Cli/Templates/mysql.hbs
@@ -1,0 +1,51 @@
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysql-secrets
+labels:
+  app: mysql
+type: Opaque
+data:
+  MYSQL_ROOT_PASSWORD: {{RootPassword}}
+---
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: mysql-statefulset
+  labels:
+    app: mysql
+spec:
+  serviceName: "mysql"
+  replicas: 1
+  selector:
+    matchLabels:
+      app: mysql
+  template:
+    metadata:
+      labels:
+        app: mysql
+    spec:
+      containers:
+        - name: mysql
+          image: mysql:latest
+          envFrom:
+            - secretRef:
+            name: mysql-secrets
+          ports:
+            - containerPort: 3306
+              name: mysqldb
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: mysql-service
+  labels:
+    app: mysql
+spec:
+  type: ClusterIP
+  ports:
+    - port: 3306
+      name: mysql
+  selector:
+    app: mysql

--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromDockerfilesAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromDockerfilesAction.cs
@@ -16,7 +16,7 @@ public sealed class BuildAndPushContainersFromDockerfilesAction(
             return true;
         }
 
-        var dockerfileProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireLiterals.Dockerfile) as DockerfileProcessor;
+        var dockerfileProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireComponentLiterals.Dockerfile) as DockerfileProcessor;
 
         Logger.MarkupLine("\r\n[bold]Building all dockerfile resources, and pushing containers:[/]\r\n");
 

--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
@@ -16,7 +16,7 @@ public sealed class BuildAndPushContainersFromProjectsAction(
             return true;
         }
 
-        var projectProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireLiterals.Project) as ProjectProcessor;
+        var projectProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireComponentLiterals.Project) as ProjectProcessor;
 
         Logger.MarkupLine("\r\n[bold]Building all project resources, and pushing containers:[/]\r\n");
 

--- a/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
@@ -19,7 +19,7 @@ public sealed class PopulateContainerDetailsForProjectsAction(
 
     private async Task HandleProjects()
     {
-        var projectProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireLiterals.Project) as ProjectProcessor;
+        var projectProcessor = Services.GetRequiredKeyedService<IProcessor>(AspireComponentLiterals.Project) as ProjectProcessor;
 
         Logger.MarkupLine("\r\n[bold]Gathering container details for each project in selected components[/]\r\n");
 

--- a/src/Aspirate.Processors/BaseProcessor.cs
+++ b/src/Aspirate.Processors/BaseProcessor.cs
@@ -36,11 +36,12 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
     /// </returns>
     private readonly Dictionary<string, Func<string, Dictionary<string, Resource>, string>> _typeHandlers = new()
     {
-        [AspireLiterals.Redis] = (resourceName, resources) => "redis",
-        [AspireLiterals.PostgresDatabase] = (resourceName, resources) => $"host=postgres-service;database={resourceName};username=postgres;password=postgres;",
-        [AspireLiterals.Container] = (resourceName, resources) => ReplaceConnectionStringPlaceholders(resources[resourceName] as AspireContainer, resources),
-        [AspireLiterals.RabbitMq] = (resourceName, resources) => "amqp://guest:guest@rabbitmq-service:5672",
-        [AspireLiterals.SqlServer] = (resourceName, resources) => $"Server=sqlserver-service,1433;User ID=sa;Password={resources[resourceName].Env["SaPassword"]};TrustServerCertificate=true;",
+        [AspireComponentLiterals.Redis] = (_, _) => "redis",
+        [AspireComponentLiterals.PostgresDatabase] = (resourceName, _) => $"host=postgres-service;database={resourceName};username=postgres;password=postgres;",
+        [AspireComponentLiterals.Container] = (resourceName, resources) => ReplaceConnectionStringPlaceholders(resources[resourceName] as AspireContainer, resources),
+        [AspireComponentLiterals.RabbitMq] = (_, _) => "amqp://guest:guest@rabbitmq-service:5672",
+        [AspireComponentLiterals.SqlServer] = (resourceName, resources) => $"Server=sqlserver-service,1433;User ID=sa;Password={resources[resourceName].Env["SaPassword"]};TrustServerCertificate=true;",
+        [AspireComponentLiterals.MySqlServer] = (resourceName, resources) => $"Server=mysql-service;Port=3306;User ID=root;Password={resources[resourceName].Env["RootPassword"]};",
     };
 
     /// <summary>
@@ -71,6 +72,7 @@ public abstract partial class BaseProcessor<TTemplateData> : IProcessor where TT
         [TemplateLiterals.ComponentKustomizeType] = $"{TemplateLiterals.ComponentKustomizeType}.hbs",
         [TemplateLiterals.RedisType] = $"{TemplateLiterals.RedisType}.hbs",
         [TemplateLiterals.SqlServerType] = $"{TemplateLiterals.SqlServerType}.hbs",
+        [TemplateLiterals.MysqlServerType] = $"{TemplateLiterals.MysqlServerType}.hbs",
         [TemplateLiterals.RabbitMqType] = $"{TemplateLiterals.RabbitMqType}.hbs",
         [TemplateLiterals.PostgresServerType] = $"{TemplateLiterals.PostgresServerType}.hbs",
     };

--- a/src/Aspirate.Processors/Container/ContainerProcessor.cs
+++ b/src/Aspirate.Processors/Container/ContainerProcessor.cs
@@ -14,7 +14,7 @@ public class ContainerProcessor(
         : BaseProcessor<ContainerTemplateData>(fileSystem, console)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.Container;
+    public override string ResourceType => AspireComponentLiterals.Container;
 
     private readonly IReadOnlyCollection<string> _manifests =
     [

--- a/src/Aspirate.Processors/Dockerfile/DockerfileProcessor.cs
+++ b/src/Aspirate.Processors/Dockerfile/DockerfileProcessor.cs
@@ -14,7 +14,7 @@ public class DockerfileProcessor(
         : BaseProcessor<DockerfileTemplateData>(fileSystem, console)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.Dockerfile;
+    public override string ResourceType => AspireComponentLiterals.Dockerfile;
 
     private readonly IReadOnlyCollection<string> _manifests =
     [

--- a/src/Aspirate.Processors/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Processors/Extensions/ServiceCollectionExtensions.cs
@@ -11,15 +11,17 @@ public static class ServiceCollectionExtensions
     /// <param name="services">The service collection to add the processors to.</param>
     public static void AddAspirateProcessors(this IServiceCollection services) =>
         services
-            .RegisterProcessor<PostgresServerProcessor>(AspireLiterals.PostgresServer)
-            .RegisterProcessor<PostgresDatabaseProcessor>(AspireLiterals.PostgresDatabase)
-            .RegisterProcessor<ProjectProcessor>(AspireLiterals.Project)
-            .RegisterProcessor<DockerfileProcessor>(AspireLiterals.Dockerfile)
-            .RegisterProcessor<RedisProcessor>(AspireLiterals.Redis)
-            .RegisterProcessor<RabbitMqProcessor>(AspireLiterals.RabbitMq)
-            .RegisterProcessor<ContainerProcessor>(AspireLiterals.Container)
-            .RegisterProcessor<SqlServerProcessor>(AspireLiterals.SqlServer)
-            .RegisterProcessor<SqlServerDatabaseProcessor>(AspireLiterals.SqlServerDatabase)
+            .RegisterProcessor<PostgresServerProcessor>(AspireComponentLiterals.PostgresServer)
+            .RegisterProcessor<PostgresDatabaseProcessor>(AspireComponentLiterals.PostgresDatabase)
+            .RegisterProcessor<ProjectProcessor>(AspireComponentLiterals.Project)
+            .RegisterProcessor<DockerfileProcessor>(AspireComponentLiterals.Dockerfile)
+            .RegisterProcessor<RedisProcessor>(AspireComponentLiterals.Redis)
+            .RegisterProcessor<RabbitMqProcessor>(AspireComponentLiterals.RabbitMq)
+            .RegisterProcessor<ContainerProcessor>(AspireComponentLiterals.Container)
+            .RegisterProcessor<SqlServerProcessor>(AspireComponentLiterals.SqlServer)
+            .RegisterProcessor<SqlServerDatabaseProcessor>(AspireComponentLiterals.SqlServerDatabase)
+            .RegisterProcessor<MySqlServerProcessor>(AspireComponentLiterals.MySqlServer)
+            .RegisterProcessor<MySqlDatabaseProcessor>(AspireComponentLiterals.MySqlDatabase)
             .RegisterProcessor<FinalProcessor>(AspireLiterals.Final);
 
     /// <summary>

--- a/src/Aspirate.Processors/GlobalUsings.cs
+++ b/src/Aspirate.Processors/GlobalUsings.cs
@@ -6,6 +6,7 @@ global using System.Text.RegularExpressions;
 global using Aspirate.Processors.Container;
 global using Aspirate.Processors.Dockerfile;
 global using Aspirate.Processors.Final;
+global using Aspirate.Processors.MySql;
 global using Aspirate.Processors.Postgresql;
 global using Aspirate.Processors.Project;
 global using Aspirate.Processors.RabbitMQ;

--- a/src/Aspirate.Processors/MySql/MySqlDatabaseProcessor.cs
+++ b/src/Aspirate.Processors/MySql/MySqlDatabaseProcessor.cs
@@ -1,0 +1,16 @@
+namespace Aspirate.Processors.MySql;
+
+public class MySqlDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole console) : BaseProcessor<MySqlDatabaseTemplateData>(fileSystem, console)
+{
+    /// <inheritdoc />
+    public override string ResourceType => AspireComponentLiterals.MySqlDatabase;
+
+    /// <inheritdoc />
+    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
+        JsonSerializer.Deserialize<MySqlDatabase>(ref reader);
+
+    public override Task<bool> CreateManifests(KeyValuePair<string, Resource> resource, string outputPath, string imagePullPolicy,
+        string? templatePath = null, bool? disableSecrets = false) =>
+        // Do nothing for databases, they are there for configuration.
+        Task.FromResult(true);
+}

--- a/src/Aspirate.Processors/MySql/MySqlDatabaseTemplateData.cs
+++ b/src/Aspirate.Processors/MySql/MySqlDatabaseTemplateData.cs
@@ -1,0 +1,8 @@
+namespace Aspirate.Processors.MySql;
+
+public sealed class MySqlDatabaseTemplateData(
+    string name,
+    Dictionary<string, string> env,
+    IReadOnlyCollection<string> manifests,
+    bool isService)
+    : BaseTemplateData(null, null, null, manifests, false);

--- a/src/Aspirate.Processors/MySql/MySqlServerProcessor.cs
+++ b/src/Aspirate.Processors/MySql/MySqlServerProcessor.cs
@@ -1,0 +1,48 @@
+namespace Aspirate.Processors.MySql;
+
+public sealed class MySqlServerProcessor(IFileSystem fileSystem, IAnsiConsole console, IPasswordGenerator passwordGenerator) : BaseProcessor<MySqlServerTemplateData>(fileSystem, console)
+{
+    private readonly IReadOnlyCollection<string> _manifests =
+    [
+        $"{TemplateLiterals.MysqlServerType}.yml",
+    ];
+
+    /// <inheritdoc />
+    public override string ResourceType => AspireComponentLiterals.MySqlServer;
+
+    /// <inheritdoc />
+    public override Resource Deserialize(ref Utf8JsonReader reader)
+    {
+        var resource = JsonSerializer.Deserialize<MySqlServer>(ref reader);
+        resource.Env = new()
+        {
+            ["RootPassword"] = passwordGenerator.Generate().ToBase64(),
+        };
+
+        return resource;
+    }
+
+    public override Task<bool> CreateManifests(
+        KeyValuePair<string, Resource> resource,
+        string outputPath,
+        string imagePullPolicy,
+        string? templatePath,
+        bool? disableSecrets = false)
+    {
+        var resourceOutputPath = Path.Combine(outputPath, resource.Key);
+
+        EnsureOutputDirectoryExistsAndIsClean(resourceOutputPath);
+
+        var data = new MySqlServerTemplateData(_manifests)
+        {
+            RootPassword = resource.Value.Env["RootPassword"],
+        };
+
+        CreateCustomManifest(resourceOutputPath, $"{TemplateLiterals.MysqlServerType}.yml", TemplateLiterals.MysqlServerType, data, templatePath);
+        CreateComponentKustomizeManifest(resourceOutputPath, data, templatePath);
+
+        LogCompletion(resourceOutputPath);
+
+        return Task.FromResult(true);
+    }
+}

--- a/src/Aspirate.Processors/MySql/MySqlServerTemplateData.cs
+++ b/src/Aspirate.Processors/MySql/MySqlServerTemplateData.cs
@@ -1,0 +1,7 @@
+namespace Aspirate.Processors.MySql;
+
+public sealed class MySqlServerTemplateData(IReadOnlyCollection<string> manifests)
+    : BaseTemplateData(null, null, null, manifests, false)
+{
+    public required string RootPassword { get; set; }
+}

--- a/src/Aspirate.Processors/Postgresql/PostgresDatabaseProcessor.cs
+++ b/src/Aspirate.Processors/Postgresql/PostgresDatabaseProcessor.cs
@@ -6,7 +6,7 @@ namespace Aspirate.Processors.Postgresql;
 public class PostgresDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole console) : BaseProcessor<PostgresDatabaseTemplateData>(fileSystem, console)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.PostgresDatabase;
+    public override string ResourceType => AspireComponentLiterals.PostgresDatabase;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>

--- a/src/Aspirate.Processors/Postgresql/PostgresServerProcessor.cs
+++ b/src/Aspirate.Processors/Postgresql/PostgresServerProcessor.cs
@@ -11,7 +11,7 @@ public class PostgresServerProcessor(IFileSystem fileSystem, IAnsiConsole consol
     ];
 
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.PostgresServer;
+    public override string ResourceType => AspireComponentLiterals.PostgresServer;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>

--- a/src/Aspirate.Processors/Project/ProjectProcessor.cs
+++ b/src/Aspirate.Processors/Project/ProjectProcessor.cs
@@ -12,7 +12,7 @@ public class ProjectProcessor(
         : BaseProcessor<ProjectTemplateData>(fileSystem, console)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.Project;
+    public override string ResourceType => AspireComponentLiterals.Project;
 
     private readonly IReadOnlyCollection<string> _manifests =
     [

--- a/src/Aspirate.Processors/RabbitMQ/RabbitMQProcessor.cs
+++ b/src/Aspirate.Processors/RabbitMQ/RabbitMQProcessor.cs
@@ -13,7 +13,7 @@ public class RabbitMqProcessor(IFileSystem fileSystem, IAnsiConsole console) : B
     ];
 
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.RabbitMq;
+    public override string ResourceType => AspireComponentLiterals.RabbitMq;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>

--- a/src/Aspirate.Processors/Redis/RedisProcessor.cs
+++ b/src/Aspirate.Processors/Redis/RedisProcessor.cs
@@ -13,7 +13,7 @@ public class RedisProcessor(IFileSystem fileSystem, IAnsiConsole console) : Base
     ];
 
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.Redis;
+    public override string ResourceType => AspireComponentLiterals.Redis;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>

--- a/src/Aspirate.Processors/SqlServer/SqlServerDatabaseProcessor.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerDatabaseProcessor.cs
@@ -8,7 +8,7 @@ namespace Aspirate.Processors.SqlServer;
 public class SqlServerDatabaseProcessor(IFileSystem fileSystem, IAnsiConsole console) : BaseProcessor<SqlServerDatabaseTemplateData>(fileSystem, console)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.SqlServerDatabase;
+    public override string ResourceType => AspireComponentLiterals.SqlServerDatabase;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader) =>

--- a/src/Aspirate.Processors/SqlServer/SqlServerProcessor.cs
+++ b/src/Aspirate.Processors/SqlServer/SqlServerProcessor.cs
@@ -8,7 +8,7 @@ public sealed class SqlServerProcessor(IFileSystem fileSystem, IAnsiConsole cons
     ];
 
     /// <inheritdoc />
-    public override string ResourceType => AspireLiterals.SqlServer;
+    public override string ResourceType => AspireComponentLiterals.SqlServer;
 
     /// <inheritdoc />
     public override Resource? Deserialize(ref Utf8JsonReader reader)

--- a/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
@@ -1,0 +1,24 @@
+namespace Aspirate.Shared.Literals;
+
+[ExcludeFromCodeCoverage]
+public static class AspireComponentLiterals
+{
+    public const string PostgresServer = "postgres.server.v0";
+    public const string PostgresDatabase = "postgres.database.v0";
+
+    public const string Project = "project.v0";
+
+    public const string Dockerfile = "dockerfile.v0";
+
+    public const string Container = "container.v0";
+
+    public const string Redis = "redis.v0";
+
+    public const string RabbitMq = "rabbitmq.server.v0";
+
+    public const string SqlServer = "sqlserver.server.v1";
+    public const string SqlServerDatabase = "sqlserver.database.v1";
+
+    public const string MySqlServer = "mysql.server.v0";
+    public const string MySqlDatabase = "mysql.database.v0";
+}

--- a/src/Aspirate.Shared/Literals/AspireLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireLiterals.cs
@@ -3,16 +3,9 @@ namespace Aspirate.Shared.Literals;
 [ExcludeFromCodeCoverage]
 public static class AspireLiterals
 {
-    public const string PostgresServer = "postgres.server.v0";
-    public const string PostgresDatabase = "postgres.database.v0";
-    public const string Project = "project.v0";
-    public const string Dockerfile = "dockerfile.v0";
-    public const string Container = "container.v0";
-    public const string Redis = "redis.v0";
-    public const string RabbitMq = "rabbitmq.server.v0";
-    public const string SqlServer = "sqlserver.server.v1";
-    public const string SqlServerDatabase = "sqlserver.database.v1";
     public const string Final = "final";
+
     public const string DefaultManifestFile = "manifest.json";
+
     public const string ManifestPublisherArgument = "manifest";
 }

--- a/src/Aspirate.Shared/Literals/TemplateLiterals.cs
+++ b/src/Aspirate.Shared/Literals/TemplateLiterals.cs
@@ -1,13 +1,14 @@
 namespace Aspirate.Shared.Literals;
 
 [ExcludeFromCodeCoverage]
-public class TemplateLiterals
+public static class TemplateLiterals
 {
     public const string TemplatesFolder = "Templates";
     public const string DeploymentType = "deployment";
     public const string ServiceType = "service";
     public const string RedisType = "redis";
     public const string SqlServerType = "sqlserver";
+    public const string MysqlServerType = "mysql";
     public const string RabbitMqType = "rabbitmq";
     public const string PostgresServerType = "postgres-server";
     public const string ComponentKustomizeType = "kustomization";

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/MySqlDatabase.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/MySqlDatabase.cs
@@ -1,0 +1,12 @@
+
+namespace Aspirate.Shared.Models.AspireManifests.Components.V0;
+
+[ExcludeFromCodeCoverage]
+public class MySqlDatabase : Resource
+{
+    /// <summary>
+    /// The parent server of the database.
+    /// </summary>
+    [JsonPropertyName("parent")]
+    public string? Parent { get; set; }
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/MySqlServer.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/MySqlServer.cs
@@ -1,0 +1,4 @@
+namespace Aspirate.Shared.Models.AspireManifests.Components.V0;
+
+[ExcludeFromCodeCoverage]
+public class MySqlServer : Resource;

--- a/tests/Aspirate.Tests/ActionsTests/BaseActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/BaseActionTests.cs
@@ -119,7 +119,7 @@ public abstract class BaseActionTests<TSystemUnderTest> where TSystemUnderTest :
         var postgres = new Container
         {
             Name = resourceName,
-            Type = AspireLiterals.Container,
+            Type = AspireComponentLiterals.Container,
             Image = "postgres:latest",
             ConnectionString = $"Host={{{resourceName}.bindings.tcp.host}};Port={{{resourceName}.bindings.tcp.port}};Username=postgres;Password={{{resourceName}.inputs.password}}",
             Bindings = new()

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/LoadAspireManifestActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/LoadAspireManifestActionTests.cs
@@ -23,7 +23,7 @@ public class LoadAspireManifestActionTests : BaseActionTests<LoadAspireManifestA
         // Assert
         result.Should().BeTrue();
         state.SelectedProjectComponents.Should().HaveCount(2);
-        state.LoadedAspireManifestResources.Keys.Count.Should().Be(8);
+        state.LoadedAspireManifestResources.Keys.Count.Should().Be(10);
     }
 
     [Fact]
@@ -41,6 +41,6 @@ public class LoadAspireManifestActionTests : BaseActionTests<LoadAspireManifestA
         // Assert
         result.Should().BeTrue();
         state.SelectedProjectComponents.Should().HaveCount(2);
-        state.LoadedAspireManifestResources.Keys.Count.Should().Be(8);
+        state.LoadedAspireManifestResources.Keys.Count.Should().Be(10);
     }
 }

--- a/tests/Aspirate.Tests/ProcessorTests/ContainerProcessorTests.cs
+++ b/tests/Aspirate.Tests/ProcessorTests/ContainerProcessorTests.cs
@@ -15,7 +15,7 @@ public class ContainerProcessorTests
 
         var resource = new Container
         {
-            Type = AspireLiterals.Container,
+            Type = AspireComponentLiterals.Container,
             ConnectionString = "Host={postgrescontainer.bindings.tcp.host};Port={postgrescontainer.bindings.tcp.port};Username=postgres;Password={postgrescontainer.inputs.password}",
             Inputs = new()
             {

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -134,18 +134,27 @@ public class ManifestFileParserServiceTest
         var result = state.LoadedAspireManifestResources;
 
         // Assert
-        result.Should().HaveCount(8);
+        result.Should().HaveCount(10);
         result["postgres"].Should().BeOfType<PostgresServer>();
+
         result["sqlserver"].Should().BeOfType<SqlServer>();
         result["sqlserver"].Env["SaPassword"].Should().NotBeNull().And.NotBeEmpty();
         result["sqldb"].Should().BeOfType<SqlServerDatabase>();
+
+        result["mysqlserver"].Should().BeOfType<MySqlServer>();
+        result["mysqlserver"].Env["RootPassword"].Should().NotBeNull().And.NotBeEmpty();
+        result["mysqldb"].Should().BeOfType<MySqlDatabase>();
+
         result["catalogdb"].Should().BeOfType<PostgresDatabase>();
+
         result["basketcache"].Should().BeOfType<Redis>();
+
         result["catalogservice"].Should().BeOfType<Project>();
         result["catalogservice"].Env.Should().ContainKey("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES");
         result["catalogservice"].Env["OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES"].Should().Be("true");
         result["catalogservice"].Env.Should().ContainKey("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES");
         result["catalogservice"].Env["OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES"].Should().Be("true");
+
         result["anotherservice"].Should().BeOfType<Project>();
         result["anotherservice"].Env.Should().ContainKey("OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES");
         result["anotherservice"].Env["OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES"].Should().Be("true");

--- a/tests/Aspirate.Tests/TestData/manifest.json
+++ b/tests/Aspirate.Tests/TestData/manifest.json
@@ -6,6 +6,9 @@
       "sqlserver": {
         "type": "sqlserver.server.v1"
       },
+      "mysqlserver": {
+        "type": "mysql.server.v0"
+      },
       "catalogdb": {
         "type": "postgres.database.v0",
         "parent": "postgres"
@@ -13,6 +16,10 @@
       "sqldb": {
         "type": "sqlserver.database.v1",
         "parent": "sqlserver"
+      },
+      "mysqldb": {
+        "type": "mysql.database.v0",
+        "parent": "mysqlserver"
       },
       "basketcache": {
         "type": "redis.v0"


### PR DESCRIPTION
This update adds MySQL server and MySQL database processing capabilities to Aspirate. It also generalizes 'AspireLiterals' to 'AspireComponentLiterals' for wider usage in multiple contexts. Additionally, the expected count of LoadedAspireManifestResources has been updated in corresponding tests.
