### PR TITLE
75 QA: ENV variables while deploying Node apps with Dockerfile

### DIFF
--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -1,3 +1,5 @@
+using NSubstitute.Core;
+
 namespace Aspirate.Tests.ServiceTests;
 
 public class ContainerCompositionServiceTest
@@ -69,5 +71,56 @@ public class ContainerCompositionServiceTest
         // Assert
         await shellExecutionService.Received(2).ExecuteCommand(Arg.Is<ShellCommandOptions>(options => options.Command != null && options.ArgumentsBuilder != null));
         result.Should().BeTrue();
+    }
+
+    [Fact]
+    public async Task BuildAndPushContainerForDockerfile_ShouldSetEnvVarsAsBuildArgs_WhenCalled()
+    {
+        // Arrange
+        var fileSystem = new MockFileSystem();
+        fileSystem.AddFile("/testDockerfile", string.Empty);
+        var console = new TestConsole();
+        var projectPropertyService = Substitute.For<IProjectPropertyService>();
+        var shellExecutionService = Substitute.For<IShellExecutionService>();
+
+        var service = new ContainerCompositionService(fileSystem, console, projectPropertyService, shellExecutionService);
+
+        var dockerfile = new Dockerfile
+        {
+            Path = "/testDockerfile",
+            Context = "testContext",
+            Env = new()
+            {
+                ["TestArg"] = "TestValue",
+                ["TestArgTwo"] = "TestValueTwo",
+            },
+        };
+
+        shellExecutionService.ExecuteCommand(Arg.Is<ShellCommandOptions>(options => options.Command != null && options.ArgumentsBuilder != null))
+            .Returns(Task.FromResult(new ShellCommandResult(true, "test", string.Empty, 0)));
+
+        // Act
+        await service.BuildAndPushContainerForDockerfile(dockerfile, "testBuilder", "testImageName", "testRegistry", true);
+
+        // Assert
+        var calls = shellExecutionService.ReceivedCalls().ToArray();
+        calls.Length.Should().Be(2);
+
+        var buildCall = calls[0];
+        VerifyDockerCall(buildCall, "build --tag \"testRegistry/testImageName:latest\" --build-arg TestArg=\"TestValue\" --build-arg TestArgTwo=\"TestValueTwo\" --file \"/testDockerfile\" testContext");
+
+        var pushCall = calls[1];
+        VerifyDockerCall(pushCall, "push testRegistry/testImageName:latest");
+    }
+
+    private static void VerifyDockerCall(ICall call, string expectedArgumentsOutput)
+    {
+        if (call.GetArguments()[0] is not ShellCommandOptions options)
+        {
+            throw new InvalidOperationException("The shell execution service was not called with the expected arguments.");
+        }
+
+        options.Should().NotBeNull();
+        options.ArgumentsBuilder.RenderArguments().Should().Be(expectedArgumentsOutput);
     }
 }


### PR DESCRIPTION
Container Composition Service has been updated to ensure that dockerfile environmental variables pass through the variables as --build-args when building containers.

Unit tests have been updated to ensure the results of the argument builder are the expected values.

Workaround for #75