### PR TITLE
92 Node app not being generated/built on 0.1.23 & some crash happens when building it

### DIFF
--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
@@ -24,7 +24,7 @@ public sealed class BuildAndPushContainersFromProjectsAction(
 
         foreach (var resource in CurrentState.SelectedProjectComponents)
         {
-            await projectProcessor.BuildAndPushProjectContainer(resource, CurrentState.NonInteractive);
+            await projectProcessor.BuildAndPushProjectContainer(resource, CurrentState.ContainerBuilder, CurrentState.NonInteractive);
         }
 
         Logger.MarkupLine("\r\n[bold]Building and push completed for all selected project components.[/]");

--- a/src/Aspirate.Processors/Resources/Project/ProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/ProjectProcessor.cs
@@ -60,7 +60,7 @@ public sealed class ProjectProcessor(
         return Task.FromResult(true);
     }
 
-    public async Task BuildAndPushProjectContainer(KeyValuePair<string, Resource> resource, bool nonInteractive)
+    public async Task BuildAndPushProjectContainer(KeyValuePair<string, Resource> resource, string builder, bool nonInteractive)
     {
         var project = resource.Value as AspireProject;
 
@@ -69,7 +69,7 @@ public sealed class ProjectProcessor(
             throw new InvalidOperationException($"Container details for project {resource.Key} not found.");
         }
 
-        await containerCompositionService.BuildAndPushContainerForProject(project, containerDetails, nonInteractive);
+        await containerCompositionService.BuildAndPushContainerForProject(project, containerDetails, builder, nonInteractive);
 
         _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
     }

--- a/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
@@ -9,8 +9,11 @@ public sealed class ContainerCompositionService(
     public async Task<bool> BuildAndPushContainerForProject(
         Project project,
         MsBuildContainerProperties containerDetails,
+        string builder,
         bool nonInteractive = false)
     {
+        await CheckIfBuilderIsRunning(builder);
+
         var fullProjectPath = filesystem.NormalizePath(project.Path);
 
         var argumentsBuilder = ArgumentsBuilder.Create();

--- a/src/Aspirate.Services/Implementations/ShellExecutionService.cs
+++ b/src/Aspirate.Services/Implementations/ShellExecutionService.cs
@@ -50,19 +50,26 @@ public class ShellExecutionService(IAnsiConsole console, IFileSystem fileSystem)
 
     public async Task<bool> ExecuteCommandWithEnvironmentNoOutput(string command, ArgumentsBuilder argumentsBuilder, IReadOnlyDictionary<string, string?> environmentVariables)
     {
-        var arguments = argumentsBuilder.RenderArguments();
+        try
+        {
+            var arguments = argumentsBuilder.RenderArguments();
 
-        var executionCommand = Cli.Wrap(command)
-            .WithArguments(arguments)
-            .WithEnvironmentVariables(environmentVariables);
+            var executionCommand = Cli.Wrap(command)
+                .WithArguments(arguments)
+                .WithEnvironmentVariables(environmentVariables);
 
-        var commandResult = await executionCommand
-            .WithValidation(CommandResultValidation.ZeroExitCode)
-            .WithStandardErrorPipe(PipeTarget.Null)
-            .WithStandardOutputPipe(PipeTarget.Null)
-            .ExecuteAsync();
+            var commandResult = await executionCommand
+                .WithValidation(CommandResultValidation.ZeroExitCode)
+                .WithStandardErrorPipe(PipeTarget.Null)
+                .WithStandardOutputPipe(PipeTarget.Null)
+                .ExecuteAsync();
 
-        return commandResult.ExitCode == 0;
+            return commandResult.ExitCode == 0;
+        }
+        catch (Exception)
+        {
+            return false;
+        }
     }
 
     private Task HandleExitCode(string command,

--- a/src/Aspirate.Services/Interfaces/IContainerCompositionService.cs
+++ b/src/Aspirate.Services/Interfaces/IContainerCompositionService.cs
@@ -10,12 +10,13 @@ public interface IContainerCompositionService
     /// </summary>
     /// <param name="project">The project to build and push the container for.</param>
     /// <param name="containerDetails">The container properties used to build and push the container.</param>
+    /// <param name="builder">docker or podman.</param>
     /// <param name="nonInteractive">Flag indicating whether the process should run in non-interactive mode.</param>
     /// <returns>
     /// A task representing the asynchronous operation. The task result will be true if the container build and push was successful,
     /// or false if there was an error during the process.
     /// </returns>
-    Task<bool> BuildAndPushContainerForProject(Project project, MsBuildContainerProperties containerDetails, bool nonInteractive);
+    Task<bool> BuildAndPushContainerForProject(Project project, MsBuildContainerProperties containerDetails, string builder, bool nonInteractive = false);
 
     /// <summary>
     /// Build and push a container for a Dockerfile.

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -194,7 +194,7 @@ public class ManifestFileParserServiceTest
         var result = state.LoadedAspireManifestResources;
 
         // Assert
-        result.Should().HaveCount(7);
+        result.Should().HaveCount(8);
         result["catalog"].Should().BeOfType<Container>();
         result["catalogdb"].Should().BeOfType<PostgresDatabase>();
         result["basketcache"].Should().BeOfType<Container>();

--- a/tests/Aspirate.Tests/TestData/preview-2-manifest.json
+++ b/tests/Aspirate.Tests/TestData/preview-2-manifest.json
@@ -132,6 +132,25 @@
           "transport": "http"
         }
       }
+    },
+    "nodefrontend": {
+      "type": "dockerfile.v0",
+      "path": "../nodefrontend/Dockerfile",
+      "context": "../nodefrontend",
+      "env": {
+        "NODE_ENV": "development",
+        "services__catalogservice__0": "{catalogservice.bindings.http.url}",
+        "services__catalogservice__1": "{catalogservice.bindings.https.url}",
+        "PORT": "{nodefrontend.bindings.http.port}"
+      },
+      "bindings": {
+        "http": {
+          "scheme": "http",
+          "protocol": "tcp",
+          "transport": "http",
+          "containerPort": 3000
+        }
+      }
     }
   }
 }


### PR DESCRIPTION
The BuildAndPushContainerForProject method in ProjectProcessor and ContainerCompositionService have been updated to include a new builder parameter, allowing to specify 'docker' or 'podman'. In addition, tests have been added to ensure that an exception is thrown when the builder is offline. Also, checks have been implemented in ShellExecutionService to deal with situations when the builder is not running.

Handles #92
