### PR TITLE
Aspire preview 2 mssql redis support

### DIFF
--- a/src/Aspirate.Commands/Actions/ActionExecutor.cs
+++ b/src/Aspirate.Commands/Actions/ActionExecutor.cs
@@ -78,8 +78,9 @@ public class ActionExecutor(IAnsiConsole console, IServiceProvider serviceProvid
                 console.MarkupLine($"[red bold]({exitException.ExitCode}): Aspirate will now exit.[/]");
                 return exitException.ExitCode;
             }
-            catch (Exception)
+            catch (Exception e)
             {
+                console.MarkupLine($"[red]Exception: {e.Message}[/]");
                 await HandleActionFailure(executionAction.OnFailure);
                 return 1;
             }

--- a/src/Aspirate.Processors/PlaceholderSubstitutionStrategies/ResourceBindingsSubstitutionStrategy.cs
+++ b/src/Aspirate.Processors/PlaceholderSubstitutionStrategies/ResourceBindingsSubstitutionStrategy.cs
@@ -17,7 +17,7 @@ public sealed class ResourceBindingsSubstitutionStrategy : IPlaceholderSubstitut
         var parts = cleanPlaceholder.Split('.');
         var resourceName = parts[0];
 
-        if (parts.Length < 4)
+        if (parts.Length != 4)
         {
             throw new InvalidOperationException($"Binding placeholder {placeholder} is not in the expected format.");
         }


### PR DESCRIPTION
Maybe a little hacky, but I tried to fix the support for MSSQL and Redis in the Docker Compose generation with the Aspire Preview 2.
The most relevant thing is the fact that in Preview 2 the container "type" in the manifest is always "container.v0" for MSSQL and Redis, and the current code treats them as ContainerResources, skipping all the ConnectionStrings transformations in the final file.

I only tested my specific configuration with the the following command: generate --non-interactive --output-format compose --skip-build --disable-secrets

A unit test testing the redis ConnectionString result is failing, but that's expected: the Redis ConnectionString format is now "`<host>:<port of first binding>`", and the port is -1 if no bindings are found in the manifest.

Hope this helps.