### PR TITLE
117 `--container-repository-prefix` doesn't respect `--non-interactive`

### DIFF
--- a/src/Aspirate.Commands/Actions/Configuration/InitializeConfigurationAction.cs
+++ b/src/Aspirate.Commands/Actions/Configuration/InitializeConfigurationAction.cs
@@ -87,7 +87,7 @@ public class InitializeConfigurationAction(
 
     private void HandleContainerRepositoryPrefix(AspirateSettings aspirateConfiguration)
     {
-        if (!string.IsNullOrEmpty(CurrentState.ContainerRepositoryPrefix))
+        if (!string.IsNullOrEmpty(CurrentState.ContainerRepositoryPrefix) || CurrentState.NonInteractive)
         {
             aspirateConfiguration.ContainerSettings.RepositoryPrefix = CurrentState.ContainerRepositoryPrefix;
             Logger.MarkupLine($"\r\n[green]({EmojiLiterals.CheckMark}) Done:[/] Set [blue]'Container repository prefix'[/] to [blue]'{aspirateConfiguration.ContainerSettings.RepositoryPrefix}'[/].");

--- a/src/Aspirate.Commands/Options/ContainerRepositoryPrefixOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerRepositoryPrefixOption.cs
@@ -5,6 +5,7 @@ public sealed class ContainerRepositoryPrefixOption : BaseOption<string?>
     private static readonly string[] _aliases =
     {
         "--container-repository-prefix",
+        "-crp",
     };
 
     private ContainerRepositoryPrefixOption() : base(_aliases, "ASPIRATE_CONTAINER_REPOSITORY_PREFIX", null)


### PR DESCRIPTION
Also adds -crp as shorthand version
