### PR TITLE
Initial generation of `docker-compose.override.yml` to easier reuse

### DIFF
--- a/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
@@ -50,16 +50,6 @@ public sealed class GenerateDockerComposeManifestAction(IServiceProvider service
             composeOverride.Add(aspireDashboardService);
         }
 
-/*
- *  aspire:
-    container_name: "aspire"
-    image: "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0.0-preview.4"
-    ports:
-      - "18888:18888"
-      - "18889:18889"
- *
- */
-
         foreach (var resource in CurrentState.AllSelectedSupportedComponents)
         {
             ProcessIndividualComponent(resource, services, composeOverride);

--- a/src/Aspirate.Commands/AspirateState.cs
+++ b/src/Aspirate.Commands/AspirateState.cs
@@ -92,6 +92,9 @@ public class AspirateState :
     [JsonPropertyName("secretsVersion")]
     public int? Version { get; set; }
 
+    [JsonPropertyName("composeOverride")]
+    public bool ComposeOverride { get; set; }
+
     public string? Hash { get; set; }
 
     public string? SecretPassword { get; set; }

--- a/src/Aspirate.DockerCompose/Builders/NetworkBuilder.cs
+++ b/src/Aspirate.DockerCompose/Builders/NetworkBuilder.cs
@@ -7,4 +7,5 @@ public class NetworkBuilder : BuilderBase<NetworkBuilder, Network>
     }
 
     public NetworkBuilder SetExternal(bool isExternal) => WithProperty("external", isExternal);
+    public NetworkBuilder SetDefault(bool isDefault) => WithProperty("default", true);
 }

--- a/tests/Aspirate.Tests/ActionsTests/BaseActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/BaseActionTests.cs
@@ -22,8 +22,7 @@ public abstract class BaseActionTests<TSystemUnderTest> where TSystemUnderTest :
         string? kubeContext = null,
         string? password = null,
         string? outputFormat = DefaultOutputFormat,
-        bool? composeOverride = null,
-        string? networkName = null)
+        bool? composeOverride = null)
     {
         var state = new AspirateState
         {

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/GenerateDockerComposeManifestActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/GenerateDockerComposeManifestActionTests.cs
@@ -54,7 +54,7 @@ public class GenerateDockerComposeManifestActionTests : BaseActionTests<Generate
         var state = CreateAspirateStateWithInputs(() => CreateAspirateState(projectPath: DefaultProjectPath,
             outputFormat: OutputFormat.DockerCompose.Value,
             nonInteractive: true,
-            networkName: "nginx",
+            //networkName: "nginx",
             aspireManifest: Path.Combine(DefaultProjectPath, "TestData", "preview-2-manifest.json"),
             composeOverride: true),nonInteractive: true, generatedInputs: true);
 

--- a/tests/Aspirate.Tests/ActionsTests/Manifests/GenerateDockerComposeManifestActionTests.cs
+++ b/tests/Aspirate.Tests/ActionsTests/Manifests/GenerateDockerComposeManifestActionTests.cs
@@ -20,4 +20,56 @@ public class GenerateDockerComposeManifestActionTests : BaseActionTests<Generate
         // Assert
         await action.Should().ThrowAsync<ActionCausesExitException>();
     }
+
+    [Fact]
+    public async Task ExecuteGenerateDockerComposeManifestAction_ShouldGenerateDockerComposeFile()
+    {
+        // Arrange
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = true;
+        var state = CreateAspirateState(projectPath: DefaultProjectPath, outputFormat: OutputFormat.DockerCompose.Value);
+        var serviceProvider = CreateServiceProvider(state, console, new FileSystem());
+
+        var generateAspireManifestAction = GetSystemUnderTest(serviceProvider);
+
+        // Act
+        var result = await generateAspireManifestAction.ExecuteAsync();
+
+        // Assert
+        result.Should().BeTrue();
+        console.Lines.Should().ContainSingle(x => x.Contains("Done:  Generating "));
+    }
+
+    [Fact]
+    public async Task ExecuteGenerateDockerComposeManifestAction_ShouldGenerateDockerComposeOverrideFile()
+    {
+        // Arrange
+        var composeOverrideFile = Path.Combine(AppContext.BaseDirectory,"aspirate-output", "docker-compose.override.yml");
+        if (File.Exists(composeOverrideFile))
+        {
+            File.Delete(composeOverrideFile);
+        }
+        var console = new TestConsole();
+        console.Profile.Capabilities.Interactive = false;
+        var state = CreateAspirateStateWithInputs(() => CreateAspirateState(projectPath: DefaultProjectPath,
+            outputFormat: OutputFormat.DockerCompose.Value,
+            nonInteractive: true,
+            networkName: "nginx",
+            aspireManifest: Path.Combine(DefaultProjectPath, "TestData", "preview-2-manifest.json"),
+            composeOverride: true),nonInteractive: true, generatedInputs: true);
+
+        var fileSystem = new FileSystem();
+        var serviceProvider = CreateServiceProvider(state, console, fileSystem);
+
+        var generateAspireManifestAction = GetSystemUnderTest(serviceProvider);
+
+        // Act
+        var result = await generateAspireManifestAction.ExecuteAsync();
+
+        // Assert
+        result.Should().BeTrue();
+        console.Lines.Should().ContainSingle(x => x.Contains("Done:  Generating "));
+
+        File.Exists(composeOverrideFile).Should().BeTrue();
+    }
 }


### PR DESCRIPTION
This is just an initial PR suggestion for the ability to split parameters like ports into a separate file, enabling easier use in CI environments targeting different environments. I also included the generation for the aspire dashboard to be separate, and adding the environment variables to point OTL for containers to those dockerized services. The idea being that a deployment be bundle with the dashboard or not. 

Again, just an initial pass, happy to make changes as required to improve compatibility and dev experience.