### PR TITLE
fix: fixes binding evaluation issue

### DIFF
--- a/src/Aspirate.Processors/Resources/Project/ProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/ProjectProcessor.cs
@@ -148,12 +148,12 @@ public sealed class ProjectProcessor(
             return;
         }
 
-        if (resourceWithBinding.Bindings.TryGetValue("http", out var httpBinding) && httpBinding.TargetPort == 0 || httpBinding.TargetPort is null)
+        if (resourceWithBinding.Bindings.TryGetValue("http", out var httpBinding) && httpBinding.TargetPort is 0 or null)
         {
             httpBinding.TargetPort = 8080;
         }
 
-        if (resourceWithBinding.Bindings.TryGetValue("https", out var httpsBinding) && httpsBinding.TargetPort == 0 || httpsBinding.TargetPort is null)
+        if (resourceWithBinding.Bindings.TryGetValue("https", out var httpsBinding) && httpsBinding.TargetPort is 0 or null)
         {
             httpsBinding.TargetPort = 8443;
         }

--- a/tests/Aspirate.Tests/Aspirate.Tests.csproj
+++ b/tests/Aspirate.Tests/Aspirate.Tests.csproj
@@ -39,6 +39,9 @@
       <None Remove="ServiceTests\VerifyResults\ContainerDetailsServiceTests.GetContainerDetails_WhenCalled_ReturnsCorrectContainerDetails_properties=NoRepositoryWithPrefixShouldBeImage.verified.txt" />
       <None Remove="ServiceTests\VerifyResults\ContainerDetailsServiceTests.GetContainerDetails_WhenCalled_ReturnsCorrectContainerDetails_properties=NoRepositoryOrTagWithPrefixShouldBeImageLatest.verified.txt" />
       <None Remove="ServiceTests\VerifyResults\ContainerDetailsServiceTests.GetContainerDetails_WhenCalled_ReturnsCorrectContainerDetails_properties=NoRegistryOrRepositoryOrTagWithPrefixShouldBeImageLatest.verified.txt" />
+      <None Update="TestData\project-no-binding.json">
+        <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+      </None>
     </ItemGroup>
 
 </Project>

--- a/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ManifestFileParserServiceTests.cs
@@ -114,6 +114,7 @@ public class ManifestFileParserServiceTest
     [InlineData("pg-endtoend.json", 22)]
     [InlineData("sqlserver-endtoend.json", 4)]
     [InlineData("starter-with-redis.json", 3)]
+    [InlineData("project-no-binding.json", 1)]
     public async Task EndToEnd_ParsesSuccessfully(string manifestFile, int expectedCount)
     {
         // Arrange

--- a/tests/Aspirate.Tests/TestData/project-no-binding.json
+++ b/tests/Aspirate.Tests/TestData/project-no-binding.json
@@ -1,0 +1,13 @@
+{
+  "resources": {
+    "no-bindings": {
+      "type": "project.v0",
+      "path": "../ProjectWithoutBindings/ProjectWithoutBindings.csproj",
+      "env": {
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES": "true",
+        "OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY": "in_memory"
+      }
+    }
+  }
+}


### PR DESCRIPTION
if there are no bindings for a project the evaluation in PreSubstitutePlaceholders causes a NRE.

this fix just makes use of pattern matching which corrects the order of evaluation and gets around this issue.