### PR TITLE
fix json parse error in ValidateBuilderOutput (#148)

### DIFF
--- a/src/Aspirate.Services/Extensions/JsonExtensions.cs
+++ b/src/Aspirate.Services/Extensions/JsonExtensions.cs
@@ -1,0 +1,17 @@
+using System.Text.Json;
+
+namespace Aspirate.Services.Extensions;
+public static class JsonExtensions
+{
+    public static JsonDocument TryParseJson(this string json)
+    {
+        try
+        {
+            return JsonDocument.Parse(json);
+        }
+        catch (JsonException)
+        {
+            return null;
+        }
+    }
+}

--- a/src/Aspirate.Services/Extensions/JsonExtensions.cs
+++ b/src/Aspirate.Services/Extensions/JsonExtensions.cs
@@ -3,7 +3,7 @@ using System.Text.Json;
 namespace Aspirate.Services.Extensions;
 public static class JsonExtensions
 {
-    public static JsonDocument TryParseJson(this string json)
+    public static JsonDocument? TryParseJson(this string json)
     {
         try
         {

--- a/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
@@ -247,6 +247,11 @@ public sealed class ContainerCompositionService(
 
     private void ValidateBuilderOutput(ShellCommandResult builderCheckResult)
     {
+        if (!(builderCheckResult.Success && !string.IsNullOrWhiteSpace(builderCheckResult.Output) && builderCheckResult.Output.Contains("ServerErrors")))
+        {
+            return;
+        }
+
         var builderInfo = JsonDocument.Parse(builderCheckResult.Output);
 
         if (!builderInfo.RootElement.TryGetProperty("ServerErrors", out var errorProperty))

--- a/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
@@ -247,14 +247,13 @@ public sealed class ContainerCompositionService(
 
     private void ValidateBuilderOutput(ShellCommandResult builderCheckResult)
     {
-        if (!(builderCheckResult.Success && !string.IsNullOrWhiteSpace(builderCheckResult.Output) && builderCheckResult.Output.Contains("ServerErrors")))
+        if (builderCheckResult.Success)
         {
             return;
         }
 
-        var builderInfo = JsonDocument.Parse(builderCheckResult.Output);
-
-        if (!builderInfo.RootElement.TryGetProperty("ServerErrors", out var errorProperty))
+        var builderInfo = builderCheckResult.Output.TryParseJson();
+        if (builderInfo == null || !builderInfo.RootElement.TryGetProperty("ServerErrors", out var errorProperty))
         {
             return;
         }

--- a/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
+++ b/tests/Aspirate.Tests/ServiceTests/ContainerCompositionServiceTest.cs
@@ -88,7 +88,7 @@ public class ContainerCompositionServiceTest
         var response = "{\"ServerErrors\":[\"Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\"]}";
 
         shellExecutionService.ExecuteCommand(Arg.Is<ShellCommandOptions>(options => options.Command != null && options.ArgumentsBuilder != null))
-            .Returns(Task.FromResult(new ShellCommandResult(true, response, string.Empty, 0)));
+            .Returns(Task.FromResult(new ShellCommandResult(false, response, string.Empty, 0)));
 
         shellExecutionService.ExecuteCommandWithEnvironmentNoOutput(Arg.Any<string>(), Arg.Any<ArgumentsBuilder>(),Arg.Any<Dictionary<string, string?>>())
             .Returns(Task.FromResult(false));


### PR DESCRIPTION
This implementation fixes exceptions that occurs in ValidateBuilderOutput when we don't have valid json in builderCheckResult.Output.

Fixes (#148)