### PR TITLE
172 Dashboard does not work with docker compose

### DIFF
--- a/src/Aspirate.Cli/Templates/dashboard.hbs
+++ b/src/Aspirate.Cli/Templates/dashboard.hbs
@@ -63,6 +63,6 @@ spec:
       targetPort: 18888
     - name: otlp
       protocol: TCP
-      port: 4317
+      port: 18889
       targetPort: 18889
   type: ClusterIP

--- a/src/Aspirate.Cli/Templates/kustomization.hbs
+++ b/src/Aspirate.Cli/Templates/kustomization.hbs
@@ -21,7 +21,7 @@ configMapGenerator:
     - ASPNETCORE_URLS=http://+:8080;
     {{/if}}
     {{#if withDashboard}}
-    - OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:4317
+    - OTEL_EXPORTER_OTLP_ENDPOINT=http://aspire-dashboard:18889
     {{/if}}
 
 

--- a/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
+++ b/src/Aspirate.Commands/Actions/Manifests/GenerateDockerComposeManifestAction.cs
@@ -116,8 +116,7 @@ public sealed class GenerateDockerComposeManifestAction(IServiceProvider service
 
         var ports = new List<Port>
         {
-            new() { Published = 18888, Target = 18888 },
-            new() { Published = 4317, Target = 18889 }
+            new() { Published = 18888, Target = 18888 }
         };
 
         var aspireDashboard = Builder.MakeService("aspire-dashboard")

--- a/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/ResourceExtensions.cs
@@ -4,8 +4,7 @@ namespace Aspirate.Shared.Extensions;
 
 public static class ResourceExtensions
 {
-    public static Dictionary<string, string?> MapResourceToEnvVars(this KeyValuePair<string, Resource> resource,
-        bool? withDashboard)
+    public static Dictionary<string, string?> MapResourceToEnvVars(this KeyValuePair<string, Resource> resource, bool? withDashboard)
     {
         var environment = new Dictionary<string, string?>();
 
@@ -21,7 +20,7 @@ public static class ResourceExtensions
 
         if (withDashboard.GetValueOrDefault())
         {
-            environment.Add("OTEL_EXPORTER_OTLP_ENDPOINT", "http://aspire-dashboard:4317");
+            environment.Add("OTEL_EXPORTER_OTLP_ENDPOINT", "http://aspire-dashboard:18889");
         }
 
         return environment;


### PR DESCRIPTION
Also - no need to expose port 18889 on the host, as comms will work internally on the docker network compose creates.
