### PR TITLE
183 StateManagement breaks existing non-interactive build with disabled secrets

### DIFF
--- a/src/Aspirate.Commands/Commands/BaseCommand.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommand.cs
@@ -13,6 +13,7 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
     {
         AddOption(NonInteractiveOption.Instance);
         AddOption(DisableSecretsOption.Instance);
+        AddOption(DisableStateOption.Instance);
         Handler = CommandHandler.Create<TOptions, IServiceCollection>(ConstructCommand);
     }
 

--- a/src/Aspirate.Services/Implementations/StateService.cs
+++ b/src/Aspirate.Services/Implementations/StateService.cs
@@ -15,7 +15,7 @@ public class StateService(IFileSystem fs, IAnsiConsole logger, ISecretProvider s
 
     public async Task SaveState(StateManagementOptions options)
     {
-        if (options.DisableState == true)
+        if (options.DisableState == true && options.State.SecretState?.Secrets.Any() == false)
         {
             return;
         }

--- a/src/Aspirate.Services/Implementations/StateService.cs
+++ b/src/Aspirate.Services/Implementations/StateService.cs
@@ -15,7 +15,7 @@ public class StateService(IFileSystem fs, IAnsiConsole logger, ISecretProvider s
 
     public async Task SaveState(StateManagementOptions options)
     {
-        if (options.DisableState == true && options.State.SecretState?.Secrets.Any() == false)
+        if (options.DisableState == true && (options.State.SecretState is null || options.State.SecretState.Secrets.Count == 0))
         {
             return;
         }


### PR DESCRIPTION
Ensures that state management works in none interactive mode, and also add the disable state option to the BaseCommand options (doh! - missed that one). Fixes #183
