### PR TITLE
Update aspire dasjhboard image to ga image

### DIFF
--- a/src/Aspirate.Cli/Templates/dashboard.hbs
+++ b/src/Aspirate.Cli/Templates/dashboard.hbs
@@ -36,18 +36,6 @@ spec:
           env:
             - name: DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS
               value: "true"
-          livenessProbe:
-            httpGet:
-              path: /
-              port: 18888
-            initialDelaySeconds: 30
-            periodSeconds: 10
-          readinessProbe:
-            httpGet:
-              path: /
-              port: 18888
-            initialDelaySeconds: 30
-            periodSeconds: 10
 ---
 apiVersion: v1
 kind: Service

--- a/src/Aspirate.Shared/Literals/AspireLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireLiterals.cs
@@ -9,5 +9,5 @@ public static class AspireLiterals
 
     public const string ManifestPublisherArgument = "manifest";
 
-    public const string DashboardImage = "mcr.microsoft.com/dotnet/nightly/aspire-dashboard:8.0.0-preview.7";
+    public const string DashboardImage = "mcr.microsoft.com/dotnet/aspire-dashboard:8.0";
 }

--- a/src/Aspirate.Shared/Models/AspireManifests/AspireDashboard.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/AspireDashboard.cs
@@ -46,19 +46,6 @@ public static class AspireDashboard
                                 {
                                     new() { Name = "DOTNET_DASHBOARD_UNSECURED_ALLOW_ANONYMOUS", Value = "true" }
                                 },
-                                LivenessProbe =
-                                    new V1Probe
-                                    {
-                                        InitialDelaySeconds = 30,
-                                        PeriodSeconds = 10,
-                                        HttpGet = new V1HTTPGetAction { Path = "/", Port = 18888 }
-                                    },
-                                ReadinessProbe = new V1Probe
-                                {
-                                    InitialDelaySeconds = 30,
-                                    PeriodSeconds = 10,
-                                    HttpGet = new V1HTTPGetAction { Path = "/", Port = 18888 }
-                                }
                             }
                         }
                     }


### PR DESCRIPTION
- New image `mcr.microsoft.com/dotnet/aspire-dashboard:8.0`
- Remove readiness probe from aspire dashboard so it starts instantly under k8s (including `aspirate run`, no more 30 second delay
- Ensure http named ports get exposed as nodeport in `aspirate run` (such as the AspireJavascript example project)
