### PR TITLE
219 Will not publish containers for non-web projects

### DIFF
--- a/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerCompositionService.cs
@@ -1,3 +1,5 @@
+using System;
+
 namespace Aspirate.Services.Implementations;
 
 public sealed class ContainerCompositionService(
@@ -192,7 +194,7 @@ public sealed class ContainerCompositionService(
 
         argumentsBuilder
             .AppendArgument(DotNetSdkLiterals.PublishArgument, fullProjectPath)
-            .AppendArgument(DotNetSdkLiterals.PublishProfileArgument, DotNetSdkLiterals.ContainerPublishProfile)
+            .AppendArgument(DotNetSdkLiterals.ContainerTargetArgument, string.Empty, quoteValue: false)
             .AppendArgument(DotNetSdkLiterals.PublishSingleFileArgument, msbuildProperties.Properties.PublishSingleFile)
             .AppendArgument(DotNetSdkLiterals.PublishTrimmedArgument, msbuildProperties.Properties.PublishTrimmed)
             .AppendArgument(DotNetSdkLiterals.SelfContainedArgument, DotNetSdkLiterals.DefaultSelfContained)

--- a/src/Aspirate.Shared/Literals/DotNetSdkLiterals.cs
+++ b/src/Aspirate.Shared/Literals/DotNetSdkLiterals.cs
@@ -20,6 +20,7 @@ public static class DotNetSdkLiterals
     public const string NoLogoArgument = "--nologo";
     public const string LaunchProfileArgument = "--launch-profile";
     public const string RuntimeIdentifierArgument = "-r";
+    public const string ContainerTargetArgument = "-t:PublishContainer";
     public const string OsArgument = "--os";
     public const string ArchArgument = "--arch";
     public const string GetPropertyArgument = "--getProperty";
@@ -34,7 +35,6 @@ public static class DotNetSdkLiterals
     public const string ContainerImageTagArguments = $"-p:{MsBuildPropertiesLiterals.ContainerImageTagArguments}";
     public const string ErrorOnDuplicatePublishOutputFilesArgument = $"-p:{MsBuildPropertiesLiterals.ErrorOnDuplicatePublishOutputFilesArgument}";
 
-    public const string ContainerPublishProfile = "DefaultContainer";
     public const string DefaultSingleFile = "true";
     public const string DefaultSelfContained = "true";
     public const string DefaultPublishTrimmed = "false";


### PR DESCRIPTION
This commit introduces changes to the ContainerCompositionService and DotNetSdkLiterals source files. Specifically in the ContainerCompositionService file, it modifies the PublishProfileArgument to ContainerTargetArgument, with an empty string value. A few additions were also made to the DotNetSdkLiterals file, including the addition of the ContainerTargetArgument and the removal of the ContainerPublishProfile constant.
