### PR TITLE
Ensure that the latest tag isn't applied to all container builds when specifying -ct

### DIFF
--- a/src/Aspirate.Commands/Commands/BaseCommand.cs
+++ b/src/Aspirate.Commands/Commands/BaseCommand.cs
@@ -23,6 +23,9 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
     {
         var handler = ActivatorUtilities.CreateInstance<TOptionsHandler>(services.BuildServiceProvider());
 
+        var versionCheckService = handler.Services.GetRequiredService<IVersionCheckService>();
+        await versionCheckService.CheckVersion();
+
         if (CommandSkipsStateAndSecrets)
         {
             handler.CurrentState.PopulateStateFromOptions(options);
@@ -31,9 +34,6 @@ public abstract class BaseCommand<TOptions, TOptionsHandler> : Command
 
         var stateService = handler.Services.GetRequiredService<IStateService>();
         var secretService = handler.Services.GetRequiredService<ISecretService>();
-        var versionCheckService = handler.Services.GetRequiredService<IVersionCheckService>();
-
-        await versionCheckService.CheckVersion();
 
         var stateOptions = GetStateManagementOptions(options, handler, CommandAlwaysRequiresState);
 

--- a/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
@@ -122,14 +122,8 @@ public class ContainerDetailsService(IProjectPropertyService propertyService, IA
             return;
         }
 
-        // Use our custom fall-back value if it exists
         if (containerImageTag is not null)
         {
-            if (!containerImageTag.Contains("latest", StringComparer.OrdinalIgnoreCase))
-            {
-                containerImageTag.Insert(0, "latest");
-            }
-
             msBuildProperties.Properties.ContainerImageTag = string.Join(';', containerImageTag);
             return;
         }

--- a/src/Aspirate.Shared/Extensions/DockerfileParametersExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/DockerfileParametersExtensions.cs
@@ -7,8 +7,6 @@ public static class DockerfileParametersExtensions
     public static List<string> ToImageNames(this ContainerOptions options, string resourceKey)
     {
         var images = new List<string>();
-        options.Tags.Remove("latest");
-        options.Tags.Insert(0, "latest");
 
         foreach (var tag in options.Tags)
         {

--- a/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=FullParameters.verified.txt
+++ b/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=FullParameters.verified.txt
@@ -1,4 +1,3 @@
 ﻿[
-  test-registry/test-repository/test-image:latest,
   test-registry/test-repository/test-image:test-tag
 ]

--- a/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=ImageAndTag.verified.txt
+++ b/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=ImageAndTag.verified.txt
@@ -1,4 +1,3 @@
 ﻿[
-  test-image:latest,
   test-image:test-tag
 ]

--- a/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=RegistryAndPrefixAndImage.verified.txt
+++ b/tests/Aspirate.Tests/ServiceTests/VerifyResults/ContainerOptionsTests.ContainerParametersFullyPopulated_ShouldPopulateImageCorrectly_testOptions=RegistryAndPrefixAndImage.verified.txt
@@ -1,4 +1,3 @@
 ﻿[
-  test-registry/test-repository/test-image:latest,
   test-registry/test-repository/test-image:latest
 ]


### PR DESCRIPTION
To include multiple tags, specify -ct multiple times with a tag for each