### PR TITLE
Recommend 'workloads' config option for dotnet feature

### DIFF
--- a/docs/Writerside/topics/Installation-as-a-DevContainer-Feature.md
+++ b/docs/Writerside/topics/Installation-as-a-DevContainer-Feature.md
@@ -53,7 +53,7 @@ features": {
   "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
   "features": {
     "ghcr.io/devcontainers/features/docker-in-docker:2": {},
-    "ghcr.io/devcontainers/features/dotnet:2": {},
+    "ghcr.io/devcontainers/features/dotnet:2": { "workloads": "aspire" },
     "ghcr.io/devcontainers/features/kubectl-helm-minikube:1": {},
     "ghcr.io/devcontainers/features/github-cli:1": {},
     "ghcr.io/azure/azure-dev/azd:0": { "version": "latest" },
@@ -68,7 +68,6 @@ features": {
         "eamodio.gitlens",
       ]
     }
-  },
-  "onCreateCommand": "dotnet workload install aspire"
+  }
 }
 ```


### PR DESCRIPTION
Small improvement for the dev container documentation: it's now possible to declare dotnet workloads to install (as of https://github.com/devcontainers/features/pull/997), so it is no longer necessary to use a lifecycle hook to install Aspire.