### PR TITLE
Hacky container.v1 prototype

### DIFF
--- a/src/Aspirate.Processors/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Processors/ServiceCollectionExtensions.cs
@@ -15,6 +15,7 @@ public static class ServiceCollectionExtensions
         services
             .RegisterProcessor<ProjectProcessor>(AspireComponentLiterals.Project)
             .RegisterProcessor<DockerfileProcessor>(AspireComponentLiterals.Dockerfile)
+            .RegisterProcessor<ContainerV1Processor>(AspireComponentLiterals.ContainerV1)
             .RegisterProcessor<ContainerProcessor>(AspireComponentLiterals.Container)
             .RegisterProcessor<DaprProcessor>(AspireComponentLiterals.DaprSystem)
             .RegisterProcessor<DaprComponentProcessor>(AspireComponentLiterals.DaprComponent)

--- a/src/Aspirate.Shared/Interfaces/Processors/IDockerBuildProcessor.cs
+++ b/src/Aspirate.Shared/Interfaces/Processors/IDockerBuildProcessor.cs
@@ -1,0 +1,9 @@
+namespace Aspirate.Shared.Interfaces.Processors;
+
+public interface IDockerBuildProcessor
+{
+    public Task BuildAndPushContainerForDockerfile(KeyValuePair<string, Resource> resource, ContainerOptions options,
+        bool nonInteractive);
+
+    public void PopulateContainerImageCacheWithImage(KeyValuePair<string, Resource> resource, ContainerOptions options);
+}

--- a/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
@@ -8,6 +8,7 @@ public static class AspireComponentLiterals
     public const string Dockerfile = "dockerfile.v0";
 
     public const string Container = "container.v0";
+    public const string ContainerV1 = "container.v1";
 
     public const string DaprSystem = "dapr.v0";
     public const string DaprComponent = "dapr.component.v0";

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -164,7 +164,7 @@ public class AspirateState :
     [JsonIgnore]
     public List<KeyValuePair<string, Resource>> SelectedDockerfileComponents =>
         LoadedAspireManifestResources
-            .Where(x => x.Value is DockerfileResource && AspireComponentsToProcess.Contains(x.Key))
+            .Where(x => (x.Value is DockerfileResource || x.Value is ContainerResourceV1) && AspireComponentsToProcess.Contains(x.Key))
             .ToList();
 
     [JsonIgnore]

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Container/ContainerResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Container/ContainerResource.cs
@@ -9,7 +9,7 @@ public class ContainerResource : Resource,
     IResourceWithVolumes
 {
     [JsonPropertyName("image")]
-    public required string Image { get; set; }
+    public string? Image { get; set; }
 
     [JsonPropertyName("bindings")]
     public Dictionary<string, Binding>? Bindings { get; set; }

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Container/ContainerResourceV1.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/V0/Container/ContainerResourceV1.cs
@@ -1,0 +1,16 @@
+﻿namespace Aspirate.Shared.Models.AspireManifests.Components.V0.Container;
+
+public class ContainerResourceV1Build
+{
+    [JsonPropertyName("context")]
+    public string? Context { get; set; }
+
+    [JsonPropertyName("dockerfile")]
+    public string? Dockerfile { get; set; }
+}
+
+public class ContainerResourceV1 : ContainerResource
+{
+    [JsonPropertyName("build")]
+    public ContainerResourceV1Build? Build { get; set; }
+}

--- a/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Resource.cs
@@ -8,6 +8,7 @@ namespace Aspirate.Shared.Models.AspireManifests;
 [JsonDerivedType(typeof(ProjectResource), typeDiscriminator: "aspire.project")]
 [JsonDerivedType(typeof(DockerfileResource), typeDiscriminator: "aspire.dockerfile")]
 [JsonDerivedType(typeof(ContainerResource), typeDiscriminator: "aspire.container")]
+[JsonDerivedType(typeof(ContainerResourceV1), typeDiscriminator: "aspire.container.v1")]
 [JsonDerivedType(typeof(DaprResource), typeDiscriminator: "aspire.dapr")]
 [JsonDerivedType(typeof(DaprComponentResource), typeDiscriminator: "aspire.daprcomponent")]
 [JsonDerivedType(typeof(ParameterResource), typeDiscriminator: "aspire.parameter")]


### PR DESCRIPTION
Here's a horrible hack of how `container.v1` could maybe be supported, to fix to fix #264. I _think_
the difference is that `.v1` can have either an `image` entry to behave like v0, or a `build` entry
to do a build first. This is a complete hack, as it doesn't handle `v1` with `image`, but I think
Aspire writes those out as `v0` anyway.
