### PR TITLE
fix(#275): add support for the scheme property in endpoint bindings

### DIFF
--- a/src/Aspirate.Processors/Transformation/Bindings/BindingProcessor.cs
+++ b/src/Aspirate.Processors/Transformation/Bindings/BindingProcessor.cs
@@ -32,6 +32,7 @@ public sealed class BindingProcessor : IBindingProcessor
             Literals.Port => bindingEntry.Port.GetValueOrDefault() != 0 ? bindingEntry.Port.ToString() : bindingEntry.TargetPort.ToString(),
             Literals.TargetPort => bindingEntry.TargetPort.ToString(),
             Literals.Url => HandleUrlBinding(resourceName, bindingName, bindingEntry),
+            Literals.Scheme => bindingEntry.Scheme,
             _ => throw new InvalidOperationException($"Unknown property {bindingProperty}.")
         };
     }

--- a/src/Aspirate.Processors/Transformation/Literals.cs
+++ b/src/Aspirate.Processors/Transformation/Literals.cs
@@ -11,4 +11,5 @@ public static class Literals
     public const string ConnectionString = "connectionString";
     public const string Host = "host";
     public const string Url = "url";
+    public const string Scheme = "scheme";
 }


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Added support for the `scheme` property in endpoint bindings (#275)
- Extended the binding processor to handle scheme property replacement
- Added new constant definition for `scheme` in Literals class



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BindingProcessor.cs</strong><dd><code>Add scheme property support in binding processor</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Processors/Transformation/Bindings/BindingProcessor.cs

<li>Added support for <code>scheme</code> property in binding replacement logic<br> <li> Extended switch statement to handle the new <code>Scheme</code> property case<br>


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/276/files#diff-eac2c1dc91c875e7706b72876791c68c006e69c965be750360bf3ecd11c44e46">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Literals.cs</strong><dd><code>Add scheme constant definition</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Processors/Transformation/Literals.cs

- Added new constant `Scheme` to Literals class



</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/276/files#diff-918ad6cb728ee59932f7fde413adb31bb5a85da8bcf35fd4860b9c272e48744e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information