### PR TITLE
Possibility to specify manifest parameter values for generate command in non interactive mode (#274)

### DIFF
--- a/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
+++ b/src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs
@@ -16,13 +16,37 @@ public sealed class PopulateInputsAction(
             return Task.FromResult(true);
         }
 
-        ApplyGeneratedValues(parameterResources);
+        var parametersOverride = CurrentState.Parameters?.Select(s =>
+            {
+                var parts = s.Split('=', 2);
+                return new KeyValuePair<string, string>(parts[0], parts[1]);
+            })
+            .ToDictionary() ?? new Dictionary<string, string>();
 
-        ApplyManualValues(parameterResources);
+        var nonOverriddenParameterResources = parameterResources.Where(x => !parametersOverride.ContainsKey(x.Key)).ToArray();
+
+        ApplyGeneratedValues(nonOverriddenParameterResources);
+
+        ApplyOverriddenValues(parameterResources, parametersOverride);
+
+        ApplyManualValues(nonOverriddenParameterResources);
 
         Logger.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Input values have all been assigned.");
 
         return Task.FromResult(true);
+    }
+
+    private void ApplyOverriddenValues(KeyValuePair<string, Resource>[] parameterResources, Dictionary<string, string> overriddenValues)
+    {
+        foreach (var parameterResource in parameterResources)
+        {
+            if (overriddenValues.TryGetValue(parameterResource.Key, out var value))
+            {
+                var componentWithInput = parameterResource.Value as ParameterResource;
+                componentWithInput.Value = value;
+                Logger.MarkupLine($"[green]Overridden[/] value for [blue]{componentWithInput.Name}[/]");
+            }
+        }
     }
 
     private void ApplyManualValues(KeyValuePair<string, Resource>[] parameterResources)

--- a/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
@@ -28,5 +28,6 @@ public sealed class GenerateCommand : BaseCommand<GenerateOptions, GenerateComma
        AddOption(IncludeDashboardOption.Instance);
        AddOption(ComposeBuildsOption.Instance);
        AddOption(ReplaceSecretsOption.Instance);
+       AddOption(ParameterResourceValueOption.Instance);
     }
 }

--- a/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
@@ -21,6 +21,7 @@ public sealed class GenerateOptions : BaseCommandOptions,
     public List<string>? ContainerImageTags { get; set; }
     public string? ImagePullPolicy { get; set; }
     public string? OutputFormat { get; set; }
+    public List<string>? Parameters { get; set; }
     public string? RuntimeIdentifier { get; set; }
     public List<string>? ComposeBuilds { get; set; }
     public string? PrivateRegistryUrl { get; set; }

--- a/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
+++ b/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
@@ -1,0 +1,20 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class ParameterResourceValueOption : BaseOption<List<string>?>
+{
+    private static readonly string[] _aliases =
+    [
+        "-pa",
+        "--parameter"
+    ];
+
+    private ParameterResourceValueOption() : base(_aliases, "ASPIRATE_PARAMETER_VALUE", null)
+    {
+        Name = nameof(IGenerateOptions.Parameters);
+        Description = "The parameter resource value.";
+        Arity = ArgumentArity.ZeroOrMore;
+        IsRequired = false;
+    }
+
+    public static ParameterResourceValueOption Instance { get; } = new();
+}

--- a/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
+++ b/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
@@ -8,4 +8,5 @@ public interface IGenerateOptions
     bool? SkipFinalKustomizeGeneration { get; set; }
     string? ImagePullPolicy { get; set; }
     string? OutputFormat { get; set; }
+    List<string>? Parameters { get; set; }
 }

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -78,6 +78,10 @@ public class AspirateState :
     public string? OutputFormat { get; set; }
 
     [RestorableStateProperty]
+    [JsonPropertyName("parameters")]
+    public List<string>? Parameters { get; set; }
+
+    [RestorableStateProperty]
     [JsonPropertyName("disableSecrets")]
     public bool? DisableSecrets { get; set; }
 


### PR DESCRIPTION
### **User description**
resolves https://github.com/prom3theu5/aspirational-manifests/issues/274
Allows to set parameters to `generate` command from command line: `generate --parameter Key1=Value1 --parameter Key2=Value2`.
Useful when used in non-interactive mode.


___

### **PR Type**
Enhancement


___

### **Description**
- Added support for specifying manifest parameters in non-interactive mode.

- Introduced new option `--parameter` for `generate` command.

- Implemented logic to override parameter values programmatically.

- Updated state and interfaces to handle parameter overrides.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PopulateInputsAction.cs</strong><dd><code>Implement parameter override handling in PopulateInputsAction</code></dd></summary>
<hr>

src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs

<li>Added logic to handle parameter overrides.<br> <li> Introduced <code>ApplyOverriddenValues</code> method for parameter assignment.<br> <li> Adjusted existing methods to integrate overridden parameters.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-db3ac56031d6c9f7349f41160ddb2e1f4496dbb0aa45383f15d879a301baa4aa">+26/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenerateCommand.cs</strong><dd><code>Add parameter option to generate command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs

<li>Added <code>ParameterResourceValueOption</code> to the <code>generate</code> command options.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-e4c0859b68eded910f4c016b28eafbef3a5b6766cfa2c9b73248287d6587b5f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenerateOptions.cs</strong><dd><code>Extend GenerateOptions with Parameters property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs

- Added `Parameters` property to handle parameter values.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-659ccd63992eb5dde9092ccfe7be7f7a8d324b6a7223d5bdde37a48a13e4d135">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ParameterResourceValueOption.cs</strong><dd><code>Add ParameterResourceValueOption for parameter input</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Options/ParameterResourceValueOption.cs

<li>Introduced <code>ParameterResourceValueOption</code> for parameter value input.<br> <li> Defined aliases and description for the option.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-02aed6294bdaee7d1d175ad9e2749e87a7cbde155630c6764b468ace622bb6c0">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IGenerateOptions.cs</strong><dd><code>Update IGenerateOptions to include Parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs

- Added `Parameters` property to the `IGenerateOptions` interface.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-5076aeb912d39cb901d8bfdc0c50e632ba1fb1021c3e15789710b87b33426d9b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AspirateState.cs</strong><dd><code>Add Parameters property to AspirateState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Shared/Models/Aspirate/AspirateState.cs

<li>Added <code>Parameters</code> property to the <code>AspirateState</code> class.<br> <li> Marked <code>Parameters</code> as restorable state property.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/277/files#diff-21f959764a8e27565e09a2426619aec80830f20968623cd349587c210e9c6968">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information