### PR TITLE
Dombrovsky 274

### DIFF
--- a/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs
@@ -28,5 +28,6 @@ public sealed class GenerateCommand : BaseCommand<GenerateOptions, GenerateComma
        AddOption(IncludeDashboardOption.Instance);
        AddOption(ComposeBuildsOption.Instance);
        AddOption(ReplaceSecretsOption.Instance);
+       AddOption(ParameterResourceValueOption.Instance);
     }
 }

--- a/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
+++ b/src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs
@@ -21,6 +21,7 @@ public sealed class GenerateOptions : BaseCommandOptions,
     public List<string>? ContainerImageTags { get; set; }
     public string? ImagePullPolicy { get; set; }
     public string? OutputFormat { get; set; }
+    public List<string>? Parameters { get; set; }
     public string? RuntimeIdentifier { get; set; }
     public List<string>? ComposeBuilds { get; set; }
     public string? PrivateRegistryUrl { get; set; }

--- a/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
+++ b/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
@@ -1,0 +1,20 @@
+namespace Aspirate.Commands.Options;
+
+public sealed class ParameterResourceValueOption : BaseOption<List<string>?>
+{
+    private static readonly string[] _aliases =
+    [
+        "-pa",
+        "--parameter"
+    ];
+
+    private ParameterResourceValueOption() : base(_aliases, "ASPIRATE_PARAMETER_VALUE", null)
+    {
+        Name = nameof(IGenerateOptions.Parameters);
+        Description = "The parameter resource value.";
+        Arity = ArgumentArity.ZeroOrMore;
+        IsRequired = false;
+    }
+
+    public static ParameterResourceValueOption Instance { get; } = new();
+}

--- a/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
+++ b/src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs
@@ -8,4 +8,5 @@ public interface IGenerateOptions
     bool? SkipFinalKustomizeGeneration { get; set; }
     string? ImagePullPolicy { get; set; }
     string? OutputFormat { get; set; }
+    List<string>? Parameters { get; set; }
 }

--- a/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
+++ b/src/Aspirate.Shared/Models/Aspirate/AspirateState.cs
@@ -78,6 +78,10 @@ public class AspirateState :
     public string? OutputFormat { get; set; }
 
     [RestorableStateProperty]
+    [JsonPropertyName("parameters")]
+    public List<string>? Parameters { get; set; }
+
+    [RestorableStateProperty]
     [JsonPropertyName("disableSecrets")]
     public bool? DisableSecrets { get; set; }
 


### PR DESCRIPTION
### **PR Type**
Enhancement


___

### **Description**
- Added support for specifying parameter values in non-interactive mode.

- Introduced `ParameterResourceValueOption` for handling parameter inputs.

- Updated logic to apply overridden and manual parameter values.

- Extended `IGenerateOptions` and `AspirateState` to include `Parameters` property.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>PopulateInputsAction.cs</strong><dd><code>Enhance parameter handling with overrides support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Actions/Secrets/PopulateInputsAction.cs

<li>Added logic to handle overridden parameter values.<br> <li> Updated <code>ApplyGeneratedValues</code> and <code>ApplyManualValues</code> to exclude <br>overridden parameters.<br> <li> Introduced <code>ApplyOverriddenValues</code> method for setting parameter values.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-db3ac56031d6c9f7349f41160ddb2e1f4496dbb0aa45383f15d879a301baa4aa">+26/-2</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenerateCommand.cs</strong><dd><code>Add parameter value option to generate command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Commands/Generate/GenerateCommand.cs

<li>Added <code>ParameterResourceValueOption</code> to the generate command options.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-e4c0859b68eded910f4c016b28eafbef3a5b6766cfa2c9b73248287d6587b5f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>GenerateOptions.cs</strong><dd><code>Extend GenerateOptions with Parameters property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Commands/Generate/GenerateOptions.cs

- Added `Parameters` property to `GenerateOptions`.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-659ccd63992eb5dde9092ccfe7be7f7a8d324b6a7223d5bdde37a48a13e4d135">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>ParameterResourceValueOption.cs</strong><dd><code>Add ParameterResourceValueOption for parameter inputs</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Options/ParameterResourceValueOption.cs

<li>Introduced <code>ParameterResourceValueOption</code> for parameter input handling.<br> <li> Defined aliases and description for the option.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-02aed6294bdaee7d1d175ad9e2749e87a7cbde155630c6764b468ace622bb6c0">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>IGenerateOptions.cs</strong><dd><code>Extend IGenerateOptions with Parameters property</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Shared/Interfaces/Commands/Contracts/IGenerateOptions.cs

- Added `Parameters` property to `IGenerateOptions` interface.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-5076aeb912d39cb901d8bfdc0c50e632ba1fb1021c3e15789710b87b33426d9b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>AspirateState.cs</strong><dd><code>Add Parameters property to AspirateState</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Shared/Models/Aspirate/AspirateState.cs

<li>Added <code>Parameters</code> property to <code>AspirateState</code>.<br> <li> Marked <code>Parameters</code> as a restorable state property.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/285/files#diff-21f959764a8e27565e09a2426619aec80830f20968623cd349587c210e9c6968">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>