### PR TITLE
fix: nullability on build args in container building for projects. Cannot call ToDictionary on null.

### DIFF
--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
@@ -31,7 +31,7 @@ public sealed class BuildAndPushContainersFromProjectsAction(
                 ContainerBuilder = CurrentState.ContainerBuilder.ToLower(),
                 Prefix = CurrentState.ContainerRepositoryPrefix,
                 Registry = CurrentState.ContainerRegistry,
-                BuildArgs = CurrentState.ContainerBuildArgs.ToDictionary(arg => arg.Split('=')[0], arg => arg.Split('=')[1]),
+                BuildArgs = CurrentState.ContainerBuildArgs?.ToDictionary(arg => arg.Split('=')[0], arg => arg.Split('=')[1]),
                 BuildContext = CurrentState.ContainerBuildContext,
                 Tags = CurrentState.ContainerImageTags
             }, CurrentState.NonInteractive, CurrentState.RuntimeIdentifier, CurrentState.PreferDockerfile);


### PR DESCRIPTION
### **PR Type**
Bug fix


___

### **Description**
- Fixed nullability issue with `BuildArgs` in container building logic.

- Prevented potential null reference exception when calling `ToDictionary`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>BuildAndPushContainersFromProjectsAction.cs</strong><dd><code>Add null check for `BuildArgs` in container building</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs

<li>Added null check for <code>CurrentState.ContainerBuildArgs</code> before calling <br><code>ToDictionary</code>.<br> <li> Prevented potential runtime error due to null reference.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/292/files#diff-1ec08ca29b97d16eec3f4a95df6258c6a2973659d1c309e12676ea984f20b36b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>