### PR TITLE
Command Line Help Secret Masking

### DIFF
--- a/src/Aspirate.Cli/AspirateCli.cs
+++ b/src/Aspirate.Cli/AspirateCli.cs
@@ -1,3 +1,6 @@
+using System.CommandLine.Help;
+using Aspirate.Commands.Options;
+
 namespace Aspirate.Cli;
 
 internal class AspirateCli : RootCommand
@@ -14,6 +17,24 @@ internal class AspirateCli : RootCommand
         AnsiConsole.MarkupLine("[bold lime]Handle deployments of a .NET Aspire AppHost[/]");
         AnsiConsole.WriteLine();
     }
+
+    internal static void UseDefaultMasking(HelpContext helpContext)
+    {
+        var secretBaseOptions = helpContext.Command.Options
+            .OfType<IBaseOption>()
+            .Where(x => x.IsSecret)
+            .ToArray();
+
+        foreach (var secretBaseOption in secretBaseOptions)
+        {
+            AddDefaultMaskingForOption(helpContext, secretBaseOption);
+        }
+    }
+
+    private static void AddDefaultMaskingForOption(HelpContext helpContext, IBaseOption baseOption) =>
+        helpContext.HelpBuilder.CustomizeSymbol(
+            (Symbol)baseOption,
+            defaultValue: _ => new MaskedValue(baseOption.GetOptionDefault()?.ToString()).ToString());
 
     private static bool ShouldSkipLogo()
     {

--- a/src/Aspirate.Cli/AspirateCli.cs
+++ b/src/Aspirate.Cli/AspirateCli.cs
@@ -18,7 +18,7 @@ internal class AspirateCli : RootCommand
         AnsiConsole.WriteLine();
     }
 
-    internal static void UseDefaultMasking(HelpContext helpContext)
+    public static void UseDefaultMasking(HelpContext helpContext)
     {
         var secretBaseOptions = helpContext.Command.Options
             .OfType<IBaseOption>()

--- a/src/Aspirate.Cli/Program.cs
+++ b/src/Aspirate.Cli/Program.cs
@@ -3,5 +3,6 @@ AspirateCli.WelcomeMessage();
 return await new CommandLineBuilder(new AspirateCli())
     .UseDefaults()
     .UseDependencyInjection(services => services.RegisterAspirateEssential())
+    .UseHelp(AspirateCli.UseDefaultMasking)
     .Build()
     .InvokeAsync(args);

--- a/src/Aspirate.Commands/Options/AllowClearNamespaceOption.cs
+++ b/src/Aspirate.Commands/Options/AllowClearNamespaceOption.cs
@@ -1,17 +1,18 @@
-﻿namespace Aspirate.Commands.Options
+namespace Aspirate.Commands.Options;
+
+public sealed class AllowClearNamespaceOption : BaseOption<bool?>
 {
-    public sealed class AllowClearNamespaceOption : BaseOption<bool?>
+    private static readonly string[] _aliases = ["--clear-namespace"];
+
+    private AllowClearNamespaceOption() : base(_aliases, "ASPIRATE_ALLOW_CLEAR_NAMESPACE", null)
     {
-        private static readonly string[] _aliases = ["--clear-namespace"];
-
-        private AllowClearNamespaceOption() : base(_aliases, "ASPIRATE_ALLOW_CLEAR_NAMESPACE", null)
-        {
-            Name = nameof(IRunOptions.AllowClearNamespace);
-            Description = "Is Aspirate allowed to clear the namespace if it exists before deploying during the run command?";
-            Arity = ArgumentArity.ZeroOrOne;
-            IsRequired = false;
-        }
-
-        public static AllowClearNamespaceOption Instance { get; } = new();
+        Name = nameof(IRunOptions.AllowClearNamespace);
+        Description = "Is Aspirate allowed to clear the namespace if it exists before deploying during the run command?";
+        Arity = ArgumentArity.ZeroOrOne;
+        IsRequired = false;
     }
+
+    public static AllowClearNamespaceOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/AspireManifestOption.cs
+++ b/src/Aspirate.Commands/Options/AspireManifestOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class AspireManifestOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class AspireManifestOption : BaseOption<string?>
     }
 
     public static AspireManifestOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/BaseOption.cs
+++ b/src/Aspirate.Commands/Options/BaseOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public abstract class BaseOption<T>(
     string[] aliases,
@@ -7,6 +7,10 @@ public abstract class BaseOption<T>(
     getDefaultValue: GetOptionDefault(envName,
         defaultValue))
 {
+    public abstract bool IsSecret { get; }
+
+    public T GetOptionDefault() => GetOptionDefault(envName, defaultValue)();
+
     private static Func<TReturnValue> GetOptionDefault<TReturnValue>(string envVarName, TReturnValue defaultValue) =>
         () =>
         {

--- a/src/Aspirate.Commands/Options/BaseOption.cs
+++ b/src/Aspirate.Commands/Options/BaseOption.cs
@@ -3,13 +3,17 @@ namespace Aspirate.Commands.Options;
 public abstract class BaseOption<T>(
     string[] aliases,
     string envName,
-    T defaultValue) : Option<T>(aliases,
-    getDefaultValue: GetOptionDefault(envName,
-        defaultValue))
+    T defaultValue) :
+        Option<T>(
+            aliases,
+            getDefaultValue: GetOptionDefault(envName, defaultValue)),
+        IBaseOption
 {
     public abstract bool IsSecret { get; }
 
     public T GetOptionDefault() => GetOptionDefault(envName, defaultValue)();
+
+    object? IBaseOption.GetOptionDefault() => GetOptionDefault();
 
     private static Func<TReturnValue> GetOptionDefault<TReturnValue>(string envVarName, TReturnValue defaultValue) =>
         () =>
@@ -22,7 +26,7 @@ public abstract class BaseOption<T>(
 
             try
             {
-                return (TReturnValue) Convert.ChangeType(envValue, typeof(TReturnValue));
+                return (TReturnValue)Convert.ChangeType(envValue, typeof(TReturnValue));
             }
             catch (Exception)
             {

--- a/src/Aspirate.Commands/Options/ComposeBuildsOption.cs
+++ b/src/Aspirate.Commands/Options/ComposeBuildsOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ComposeBuildsOption : BaseOption<List<string>?>
 {
@@ -13,4 +13,6 @@ public sealed class ComposeBuildsOption : BaseOption<List<string>?>
     }
 
     public static ComposeBuildsOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ContainerBuildArgsOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerBuildArgsOption.cs
@@ -17,4 +17,6 @@ public sealed class ContainerBuildArgsOption : BaseOption<List<string>?>
     }
 
     public static ContainerBuildArgsOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ContainerBuildContextOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerBuildContextOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ContainerBuildContextOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class ContainerBuildContextOption : BaseOption<string?>
     }
 
     public static ContainerBuildContextOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ContainerBuilderOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerBuilderOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ContainerBuilderOption : BaseOption<string>
 {
@@ -10,10 +10,12 @@ public sealed class ContainerBuilderOption : BaseOption<string>
         Description = "The Container Builder: can be 'docker' or 'podman'. The default is 'docker'";
         Arity = ArgumentArity.ExactlyOne;
         IsRequired = false;
-        this.AddValidator(ValidateFormat);
+        AddValidator(ValidateFormat);
     }
 
     public static ContainerBuilderOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 
     private static void ValidateFormat(OptionResult optionResult)
     {

--- a/src/Aspirate.Commands/Options/ContainerImageTagOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerImageTagOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ContainerImageTagOption : BaseOption<List<string>?>
 {
@@ -17,4 +17,6 @@ public sealed class ContainerImageTagOption : BaseOption<List<string>?>
     }
 
     public static ContainerImageTagOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ContainerRegistryOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerRegistryOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ContainerRegistryOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class ContainerRegistryOption : BaseOption<string?>
     }
 
     public static ContainerRegistryOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ContainerRepositoryPrefixOption.cs
+++ b/src/Aspirate.Commands/Options/ContainerRepositoryPrefixOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ContainerRepositoryPrefixOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class ContainerRepositoryPrefixOption : BaseOption<string?>
     }
 
     public static ContainerRepositoryPrefixOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/DisableSecretsOption.cs
+++ b/src/Aspirate.Commands/Options/DisableSecretsOption.cs
@@ -1,17 +1,18 @@
-﻿namespace Aspirate.Commands.Options
+namespace Aspirate.Commands.Options;
+
+public sealed class DisableSecretsOption : BaseOption<bool?>
 {
-    public sealed class DisableSecretsOption : BaseOption<bool?>
+    private static readonly string[] _aliases = ["--disable-secrets"];
+
+    private DisableSecretsOption() : base(_aliases, "ASPIRATE_DISABLE_SECRETS", null)
     {
-        private static readonly string[] _aliases = ["--disable-secrets"];
-
-        private DisableSecretsOption() : base(_aliases, "ASPIRATE_DISABLE_SECRETS", null)
-        {
-            Name = nameof(ICommandOptions.DisableSecrets);
-            Description = "Disables Secret Support";
-            Arity = ArgumentArity.ZeroOrOne;
-            IsRequired = false;
-        }
-
-        public static DisableSecretsOption Instance { get; } = new();
+        Name = nameof(ICommandOptions.DisableSecrets);
+        Description = "Disables Secret Support";
+        Arity = ArgumentArity.ZeroOrOne;
+        IsRequired = false;
     }
+
+    public static DisableSecretsOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/DisableStateOption.cs
+++ b/src/Aspirate.Commands/Options/DisableStateOption.cs
@@ -1,17 +1,18 @@
-﻿namespace Aspirate.Commands.Options
+namespace Aspirate.Commands.Options;
+
+public sealed class DisableStateOption : BaseOption<bool?>
 {
-    public sealed class DisableStateOption : BaseOption<bool?>
+    private static readonly string[] _aliases = ["--disable-state", "--no-state"];
+
+    private DisableStateOption() : base(_aliases, "ASPIRATE_DISABLE_STATE", null)
     {
-        private static readonly string[] _aliases = ["--disable-state", "--no-state"];
-
-        private DisableStateOption() : base(_aliases, "ASPIRATE_DISABLE_STATE", null)
-        {
-            Name = nameof(ICommandOptions.DisableState);
-            Description = "Disables State Support";
-            Arity = ArgumentArity.ZeroOrOne;
-            IsRequired = false;
-        }
-
-        public static DisableStateOption Instance { get; } = new();
+        Name = nameof(ICommandOptions.DisableState);
+        Description = "Disables State Support";
+        Arity = ArgumentArity.ZeroOrOne;
+        IsRequired = false;
     }
+
+    public static DisableStateOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/IBaseOption.cs
+++ b/src/Aspirate.Commands/Options/IBaseOption.cs
@@ -1,0 +1,8 @@
+namespace Aspirate.Commands.Options;
+
+public interface IBaseOption
+{
+    bool IsSecret { get; }
+
+    public object? GetOptionDefault();
+}

--- a/src/Aspirate.Commands/Options/ImagePullPolicyOption.cs
+++ b/src/Aspirate.Commands/Options/ImagePullPolicyOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ImagePullPolicyOption : BaseOption<string?>
 {
@@ -10,10 +10,12 @@ public sealed class ImagePullPolicyOption : BaseOption<string?>
         Description = "The Image pull policy to use when generating manifests";
         Arity = ArgumentArity.ExactlyOne;
         IsRequired = false;
-        this.AddValidator(ValidateFormat);
+        AddValidator(ValidateFormat);
     }
 
     public static ImagePullPolicyOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 
     private static void ValidateFormat(OptionResult optionResult)
     {

--- a/src/Aspirate.Commands/Options/IncludeDashboardOption.cs
+++ b/src/Aspirate.Commands/Options/IncludeDashboardOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class IncludeDashboardOption : BaseOption<bool?>
 {
@@ -13,4 +13,6 @@ public sealed class IncludeDashboardOption : BaseOption<bool?>
     }
 
     public static IncludeDashboardOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/InputPathOption.cs
+++ b/src/Aspirate.Commands/Options/InputPathOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class InputPathOption : BaseOption<string>
 {
@@ -17,4 +17,6 @@ public sealed class InputPathOption : BaseOption<string>
     }
 
     public static InputPathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/KubernetesContextOption.cs
+++ b/src/Aspirate.Commands/Options/KubernetesContextOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class KubernetesContextOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class KubernetesContextOption : BaseOption<string?>
     }
 
     public static KubernetesContextOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/LaunchProfileOption.cs
+++ b/src/Aspirate.Commands/Options/LaunchProfileOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class LaunchProfileOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class LaunchProfileOption : BaseOption<string?>
     }
 
     public static LaunchProfileOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/NamespaceOption.cs
+++ b/src/Aspirate.Commands/Options/NamespaceOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class NamespaceOption : BaseOption<string?>
 {
@@ -16,4 +16,6 @@ public sealed class NamespaceOption : BaseOption<string?>
     }
 
     public static NamespaceOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/NonInteractiveOption.cs
+++ b/src/Aspirate.Commands/Options/NonInteractiveOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class NonInteractiveOption : BaseOption<bool?>
 {
@@ -16,4 +16,6 @@ public sealed class NonInteractiveOption : BaseOption<bool?>
     }
 
     public static NonInteractiveOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/OutputFormatOption.cs
+++ b/src/Aspirate.Commands/Options/OutputFormatOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class OutputFormatOption : BaseOption<string?>
 {
@@ -10,10 +10,12 @@ public sealed class OutputFormatOption : BaseOption<string?>
         Description = "The output format of the generated manifests. Supported values are 'kustomize', 'compose', and 'helm'.";
         Arity = ArgumentArity.ZeroOrOne;
         IsRequired = false;
-        this.AddValidator(ValidateFormat);
+        AddValidator(ValidateFormat);
     }
 
     public static OutputFormatOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 
     private static void ValidateFormat(OptionResult optionResult)
     {

--- a/src/Aspirate.Commands/Options/OutputPathOption.cs
+++ b/src/Aspirate.Commands/Options/OutputPathOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class OutputPathOption : BaseOption<string>
 {
@@ -8,7 +8,7 @@ public sealed class OutputPathOption : BaseOption<string>
         "--output-path"
     ];
 
-    private OutputPathOption() : base(_aliases,  "ASPIRATE_OUTPUT_PATH", AspirateLiterals.DefaultArtifactsPath)
+    private OutputPathOption() : base(_aliases, "ASPIRATE_OUTPUT_PATH", AspirateLiterals.DefaultArtifactsPath)
     {
         Name = nameof(IGenerateOptions.OutputPath);
         Description = "The output path for generated manifests";
@@ -17,4 +17,6 @@ public sealed class OutputPathOption : BaseOption<string>
     }
 
     public static OutputPathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
+++ b/src/Aspirate.Commands/Options/ParameterResourceValueOption.cs
@@ -17,4 +17,6 @@ public sealed class ParameterResourceValueOption : BaseOption<List<string>?>
     }
 
     public static ParameterResourceValueOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/PreferDockerfileOption.cs
+++ b/src/Aspirate.Commands/Options/PreferDockerfileOption.cs
@@ -13,4 +13,6 @@ public sealed class PreferDockerfileOption : BaseOption<bool?>
     }
 
     public static PreferDockerfileOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/PrivateRegistryEmailOption.cs
+++ b/src/Aspirate.Commands/Options/PrivateRegistryEmailOption.cs
@@ -16,4 +16,6 @@ public sealed class PrivateRegistryEmailOption : BaseOption<string?>
     }
 
     public static PrivateRegistryEmailOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/PrivateRegistryOption.cs
+++ b/src/Aspirate.Commands/Options/PrivateRegistryOption.cs
@@ -16,4 +16,6 @@ public sealed class PrivateRegistryOption : BaseOption<bool?>
     }
 
     public static PrivateRegistryOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/PrivateRegistryPasswordOption.cs
+++ b/src/Aspirate.Commands/Options/PrivateRegistryPasswordOption.cs
@@ -16,4 +16,6 @@ public sealed class PrivateRegistryPasswordOption : BaseOption<string?>
     }
 
     public static PrivateRegistryPasswordOption Instance { get; } = new();
+
+    public override bool IsSecret => true;
 }

--- a/src/Aspirate.Commands/Options/PrivateRegistryUrlOption.cs
+++ b/src/Aspirate.Commands/Options/PrivateRegistryUrlOption.cs
@@ -16,4 +16,6 @@ public sealed class PrivateRegistryUrlOption : BaseOption<string?>
     }
 
     public static PrivateRegistryUrlOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/PrivateRegistryUsernameOption.cs
+++ b/src/Aspirate.Commands/Options/PrivateRegistryUsernameOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class PrivateRegistryUsernameOption : BaseOption<string?>
 {
@@ -16,4 +16,6 @@ public sealed class PrivateRegistryUsernameOption : BaseOption<string?>
     }
 
     public static PrivateRegistryUsernameOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ProjectPathOption.cs
+++ b/src/Aspirate.Commands/Options/ProjectPathOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class ProjectPathOption : BaseOption<string>
 {
@@ -11,10 +11,12 @@ public sealed class ProjectPathOption : BaseOption<string>
     private ProjectPathOption() : base(_aliases, "ASPIRATE_PROJECT_PATH", AspirateLiterals.DefaultAspireProjectPath)
     {
         Name = nameof(IAspireOptions.ProjectPath);
-        Description =  "The path to the aspire project";
+        Description = "The path to the aspire project";
         Arity = ArgumentArity.ExactlyOne;
         IsRequired = false;
     }
 
     public static ProjectPathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/ReplaceSecretsOption.cs
+++ b/src/Aspirate.Commands/Options/ReplaceSecretsOption.cs
@@ -1,17 +1,18 @@
-﻿namespace Aspirate.Commands.Options
+namespace Aspirate.Commands.Options;
+
+public sealed class ReplaceSecretsOption : BaseOption<bool?>
 {
-    public sealed class ReplaceSecretsOption : BaseOption<bool?>
+    private static readonly string[] _aliases = ["--replace-secrets"];
+
+    private ReplaceSecretsOption() : base(_aliases, "ASPIRATE_REPLACE_SECRETS", null)
     {
-        private static readonly string[] _aliases = ["--replace-secrets"];
-
-        private ReplaceSecretsOption() : base(_aliases, "ASPIRATE_REPLACE_SECRETS", null)
-        {
-            Name = nameof(ISecretState.ReplaceSecrets);
-            Description = "Replace all secrets and inputs.";
-            Arity = ArgumentArity.ZeroOrOne;
-            IsRequired = false;
-        }
-
-        public static ReplaceSecretsOption Instance { get; } = new();
+        Name = nameof(ISecretState.ReplaceSecrets);
+        Description = "Replace all secrets and inputs.";
+        Arity = ArgumentArity.ZeroOrOne;
+        IsRequired = false;
     }
+
+    public static ReplaceSecretsOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/RollingRestartOption.cs
+++ b/src/Aspirate.Commands/Options/RollingRestartOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class RollingRestartOption : BaseOption<bool?>
 {
@@ -17,4 +17,6 @@ public sealed class RollingRestartOption : BaseOption<bool?>
     }
 
     public static RollingRestartOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/RuntimeIdentifierOption.cs
+++ b/src/Aspirate.Commands/Options/RuntimeIdentifierOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class RuntimeIdentifierOption : BaseOption<string?>
 {
@@ -13,4 +13,6 @@ public sealed class RuntimeIdentifierOption : BaseOption<string?>
     }
 
     public static RuntimeIdentifierOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/SecretPasswordOption.cs
+++ b/src/Aspirate.Commands/Options/SecretPasswordOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class SecretPasswordOption : BaseOption<string?>
 {
@@ -16,4 +16,6 @@ public sealed class SecretPasswordOption : BaseOption<string?>
     }
 
     public static SecretPasswordOption Instance { get; } = new();
+
+    public override bool IsSecret => true;
 }

--- a/src/Aspirate.Commands/Options/SkipBuildOption.cs
+++ b/src/Aspirate.Commands/Options/SkipBuildOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class SkipBuildOption : BaseOption<bool?>
 {
@@ -13,4 +13,6 @@ public sealed class SkipBuildOption : BaseOption<bool?>
     }
 
     public static SkipBuildOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/SkipFinalKustomizeGenerationOption.cs
+++ b/src/Aspirate.Commands/Options/SkipFinalKustomizeGenerationOption.cs
@@ -1,22 +1,23 @@
-﻿namespace Aspirate.Commands.Options
+namespace Aspirate.Commands.Options;
+
+public sealed class SkipFinalKustomizeGenerationOption : BaseOption<bool?>
 {
-    public sealed class SkipFinalKustomizeGenerationOption : BaseOption<bool?>
+    private static readonly string[] _aliases =
+    [
+        "-sf",
+        "--skip-final",
+        "--skip-final-kustomize-generation"
+    ];
+
+    private SkipFinalKustomizeGenerationOption() : base(_aliases, "ASPIRATE_SKIP_FINAL_KUSTOMIZE_GENERATION", null)
     {
-        private static readonly string[] _aliases =
-        [
-            "-sf",
-            "--skip-final",
-            "--skip-final-kustomize-generation"
-        ];
-
-        private SkipFinalKustomizeGenerationOption() : base(_aliases, "ASPIRATE_SKIP_FINAL_KUSTOMIZE_GENERATION", null)
-        {
-            Name = nameof(IGenerateOptions.SkipFinalKustomizeGeneration);
-            Description = "Skips The final generation of the kustomize manifest, which is the parent top level file";
-            Arity = ArgumentArity.ZeroOrOne;
-            IsRequired = false;
-        }
-
-        public static SkipFinalKustomizeGenerationOption Instance { get; } = new();
+        Name = nameof(IGenerateOptions.SkipFinalKustomizeGeneration);
+        Description = "Skips The final generation of the kustomize manifest, which is the parent top level file";
+        Arity = ArgumentArity.ZeroOrOne;
+        IsRequired = false;
     }
+
+    public static SkipFinalKustomizeGenerationOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Commands/Options/TemplatePathOption.cs
+++ b/src/Aspirate.Commands/Options/TemplatePathOption.cs
@@ -1,4 +1,4 @@
-﻿namespace Aspirate.Commands.Options;
+namespace Aspirate.Commands.Options;
 
 public sealed class TemplatePathOption : BaseOption<string?>
 {
@@ -17,4 +17,6 @@ public sealed class TemplatePathOption : BaseOption<string?>
     }
 
     public static TemplatePathOption Instance { get; } = new();
+
+    public override bool IsSecret => false;
 }

--- a/src/Aspirate.Secrets/MaskedValue.cs
+++ b/src/Aspirate.Secrets/MaskedValue.cs
@@ -1,0 +1,35 @@
+namespace Aspirate.Secrets;
+
+public class MaskedValue(
+    string? value,
+    char maskChar = '*',
+    int unmaskedHeadLength = 2,
+    int unmaskedTailLength = 2)
+{
+    public override string ToString()
+    {
+        if (value == null)
+        {
+            return string.Empty;
+        }
+
+        // We're going for best effort here--if secret is exceedingly small,
+        // we are not going to show any of it unmasked.
+        var unmaskedTotalLength = unmaskedHeadLength + unmaskedTailLength;
+
+        if (value.Length < unmaskedTotalLength * 3)
+        {
+            return new string(maskChar, value.Length);
+        }
+
+        var unmaskedHead = value[..unmaskedHeadLength];
+        var unmaskedTail = value[^unmaskedTailLength..];
+
+        var masked = new StringBuilder(value.Length);
+        masked.Append(unmaskedHead);
+        masked.Append(maskChar, value.Length - unmaskedTotalLength);
+        masked.Append(unmaskedTail);
+
+        return masked.ToString();
+    }
+}

--- a/src/Aspirate.Secrets/MaskedValue.cs
+++ b/src/Aspirate.Secrets/MaskedValue.cs
@@ -13,8 +13,8 @@ public class MaskedValue(
             return string.Empty;
         }
 
-        // We're going for best effort here--if secret is exceedingly small,
-        // we are not going to show any of it unmasked.
+        // We're going for best effort here--if the secret is exceedingly
+        // small, we are not going to show any of it unmasked.
         var unmaskedTotalLength = unmaskedHeadLength + unmaskedTailLength;
 
         if (value.Length < unmaskedTotalLength * 3)

--- a/tests/Aspirate.Tests/SecretTests/MaskedValueTests.cs
+++ b/tests/Aspirate.Tests/SecretTests/MaskedValueTests.cs
@@ -1,0 +1,60 @@
+using System.CommandLine;
+using System.CommandLine.Help;
+using System.Text;
+using Aspirate.Cli;
+
+namespace Aspirate.Tests.SecretTests;
+
+public class MaskedValueTests
+{
+    [Theory]
+    [InlineData("password", "********")]
+    [InlineData("LongPasswordTest", "Lo************st")]
+    [InlineData("5230", "****")]
+    [InlineData("523", "***")]
+    [InlineData("52", "**")]
+    [InlineData("5", "*")]
+    [InlineData("", "")]
+    [InlineData(null, "")]
+    public void MaskedValue_ShouldMaskString(string? value, string expectedMaskedString)
+    {
+        // Arrange
+        var maskedValue = new MaskedValue(value);
+
+        // Act
+        var actualMaskedString = maskedValue.ToString();
+
+        // Assert
+        Assert.Equal(expectedMaskedString, actualMaskedString);
+    }
+
+    [Theory]
+    [InlineData("password", "********")]
+    [InlineData("LongPasswordTest", "Lo************st")]
+    [InlineData("5230", "****")]
+    public void HelpBuilder_ShouldEmitMaskedString(string? value, string expectedMaskedString)
+    {
+        // Arrange
+        var expectedDefaultArgument = FormatDefaultArgument(expectedMaskedString);
+        var unexpectedSecretDefaultArgument = FormatDefaultArgument(value);
+        Environment.SetEnvironmentVariable("ASPIRATE_SECRET_PASSWORD", value);
+        var cli = new AspirateCli();
+        var parseResult = cli.Parse(["generate", "--secret-password", value]);
+        var helpBuilder = new HelpBuilder(LocalizationResources.Instance);
+        var textOut = new StringBuilder();
+        using var writer = new StringWriter(textOut);
+        var helpContext = new HelpContext(helpBuilder, parseResult.CommandResult.Command, writer, parseResult);
+        AspirateCli.UseDefaultMasking(helpContext);
+
+        // Act
+        helpBuilder.Write(helpContext);
+        writer.Flush();
+        var actualHelpOutput = textOut.ToString();
+
+        // Assert
+        Assert.Contains(expectedDefaultArgument, actualHelpOutput);
+        Assert.DoesNotContain(unexpectedSecretDefaultArgument, actualHelpOutput);
+    }
+
+    private static string FormatDefaultArgument(string defaultArgument) => $"[default: {defaultArgument}]";
+}


### PR DESCRIPTION
### **User description**
This PR adds secret masking to the `System.CommandLine` help output. In the current implementation, secrets defined via environment variable such as `ASPIRATE_SECRET_PASSWORD` are leaked as default values when help is displayed:

![image](https://github.com/user-attachments/assets/562f283e-d330-40e5-92cb-45d82dc0d92e)

This feature masks these values. In the case of secrets `< 12` characters, the secret is masked entirely:

![image](https://github.com/user-attachments/assets/f011c9df-188d-4231-94fe-4e49500c4826)

However, in the case of secrets `>= 12` characters, such as `LongerP@ssword1`, the first two and last two characters are unmasked:

![image](https://github.com/user-attachments/assets/ad78898a-c640-4dcd-ab40-549d4da78919)

While slightly intrusive, the feature was implemented using an additional `abstract` property, `BaseOption<T>.IsSecret`. Not only does this allow for automatic discovery of options containing secrets, but it also forces developers to declare whether or not any future options are considered secrets.

This PR also includes various minor refactors to follow the conventions laid out in `.editorconfig`.

___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced secret masking for default values in CLI help output.

- Added `IsSecret` property to `BaseOption` for secret identification.

- Implemented `MaskedValue` class for masking sensitive data.

- Added unit tests to validate secret masking functionality.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>18 files</summary><table>
<tr>
  <td><strong>AspirateCli.cs</strong><dd><code>Added secret masking logic in CLI help context</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-e59e327cd41b3f3b7257a17eac8f6ff390ff7c825ed8574bd859da7b2f5813bc">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Program.cs</strong><dd><code>Integrated secret masking into CLI help system</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-dd20ee9010dd57f5921ed17d19496c067cd176595a20d7bf4dbbc37a5130893f">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>AllowClearNamespaceOption.cs</strong><dd><code>Updated `AllowClearNamespaceOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-1e3b4e49e7052b43e2de35ff41c4ddf4bdffd6b093a58212517ab9b7be2890ba">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>AspireManifestOption.cs</strong><dd><code>Updated `AspireManifestOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-1bc21a8cbfc24ecf456fa4fc021e90c514199b3209cfb9a403f74b541f16dfe4">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>BaseOption.cs</strong><dd><code>Added `IsSecret` property and default value retrieval to `BaseOption`</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-04ea563ab7a01b13a93cab40ca0e802904205efa9909ae344d84a5d110326bcc">+13/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ComposeBuildsOption.cs</strong><dd><code>Updated `ComposeBuildsOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-d3014c98cfcb2a0d035a68edc4b525cf7484381be4c8e93852da7d173c7ca3e6">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerBuildArgsOption.cs</strong><dd><code>Updated `ContainerBuildArgsOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-0951613a5ebf69af21b4fde2e31b3f91b0b73b01385037fad09019c07829ff8f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerBuildContextOption.cs</strong><dd><code>Updated `ContainerBuildContextOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-b43a3835c101fa790942e8051a0479f437202e1ec7f7f70b66324036dff9b4c1">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerBuilderOption.cs</strong><dd><code>Updated `ContainerBuilderOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-52ddbd1b98311a7c55dfdd95e87659d5438d9c5a775bd6f4da28a5bb08546f68">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerImageTagOption.cs</strong><dd><code>Updated `ContainerImageTagOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-a13c33d90fdb305e1ad63e0d84493371b06663af17d7ad03c404fbbdea867e98">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerRegistryOption.cs</strong><dd><code>Updated `ContainerRegistryOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-6dc4480f7b4f5115578c41f207e0d2c460790da2b0f2916aa3a7f4e7ff49acc2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ContainerRepositoryPrefixOption.cs</strong><dd><code>Updated <code>ContainerRepositoryPrefixOption</code> to include <code>IsSecret</code> property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-bd5a0b9ff0f4e21c94fa1dcd227fb2823884772287ff203edc4692ea6a13d3c7">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>DisableSecretsOption.cs</strong><dd><code>Updated `DisableSecretsOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-454ddb01d263136b7c6ed4256ee22212f01a73e8faa6a48a61be39b6715cc689">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>DisableStateOption.cs</strong><dd><code>Updated `DisableStateOption` to include `IsSecret` property</code></dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-a7f1f66386a4093871237f2b84f62bb246391900305c40479b7df0bdb5c7674d">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>IBaseOption.cs</strong><dd><code>Introduced `IBaseOption` interface for secret handling</code>&nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-b3857bb697b1bf6e6d61d66a5bce7b59ccbf298cb5e4cf436ea3aefd88a8c8b5">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrivateRegistryPasswordOption.cs</strong><dd><code>Marked `PrivateRegistryPasswordOption` as a secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-6326b75df565e27ff035e7de0724a9d4eeccf415d7ae8126b7b327b38ded5a2e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SecretPasswordOption.cs</strong><dd><code>Marked `SecretPasswordOption` as a secret</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-853d84dc0ded6d315c6cd0023ae11ce12b094680653e69e1c96d6008928782fa">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>MaskedValue.cs</strong><dd><code>Added `MaskedValue` class for masking sensitive data</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-cd9b22f97ff2b16bf034339cecd51eb7b5a8dd826221dc2300bfa3420e1afd33">+35/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>MaskedValueTests.cs</strong><dd><code>Added unit tests for secret masking functionality</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-19d7a6a8f3c85b8893282f6a026caae3117977aef57b5d8c83d5d9d3e3a51b71">+60/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>22 files</summary><table>
<tr>
  <td><strong>ImagePullPolicyOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-82ebb93327ef591845f01bb4d35f0b9d9261ba38b59ca71512f77bf48ecadb2a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>IncludeDashboardOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-298626417fafab2504c3d299a993af468066a87a43436da91042c758dd9b97ab">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>InputPathOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-e5db4bc6360a98be635b16aa03fa14af756ec214a470c3f2a3a438bb9e7c0c34">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>KubernetesContextOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-22d89a002463f79f030c2fd0cad32d6054648a2f4cd83def81eab42244b121a2">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>LaunchProfileOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-dc3594504efb1b928a3f9ab9bf1586a662658556367b3cdf2b113fcf0fc21c34">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NamespaceOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-29d26a07a31a10cba957a8336fec93d8287b516500021f2504a5b77f66c0288e">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>NonInteractiveOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-062224bf4027dd5730ad097387bbf415860d308243cc1a8ac91e3c1d19a8631f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OutputFormatOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-49051f68f4f7a95a7a002e1fdb2dd094fbf10815344812dd111ae9a7835cd45c">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>OutputPathOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-844848a6be0a7a9499df01b5e2867a5d645a9c9a8b633e7fcded6b18cb5aa315">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ParameterResourceValueOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-02aed6294bdaee7d1d175ad9e2749e87a7cbde155630c6764b468ace622bb6c0">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PreferDockerfileOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-bd883d3c07b8c6d0d37ff121611eace56c2946f83e2efe68a8eb9f252d7433be">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrivateRegistryEmailOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-af6b7a79604200141b2df827011560beaf6df596af1e661b758e18433239221e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrivateRegistryOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-10469ae69ba84de3d1306dcdc5f083e5d11c6d1ad9e52b2f265061d9719f70d9">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrivateRegistryUrlOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-d83d6b533c66d475631c32efe6ee8e5f9aa638ef48a519ff9845d0e223867dda">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>PrivateRegistryUsernameOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-4d1b29cbf76064c208ab80675d8409490cfec28f86e489ca26d35cec63aeaf88">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ProjectPathOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-f8f8c2b846345017ac76293dd9f83ccd3209f1b3c52243560901e5fdec75aece">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>ReplaceSecretsOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-71e6749fb1bbf181907ca0ab567ff27d4f9e3cff84b801706794b30582a9a7a5">+13/-12</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>RollingRestartOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-0c7b40a0be4bd09ead1380905fdba9d70a227d35bc4725aa4c6facedad917ce8">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RuntimeIdentifierOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-ca62f52d7102045ba331673fa5171ecd8aa0af854a745e3f224ff18726b8f53d">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SkipBuildOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-7eb1a7848fbb04362675c825f6b337fad62813e3e919b9ad979cfbfae7f3440f">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>SkipFinalKustomizeGenerationOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-0832a371d66a4e53da573a21f4c03567517806da3f74f3f3eefa4fb341fafb7e">+18/-17</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>TemplatePathOption.cs</strong></td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/297/files#diff-9991bfefbe98d19349e204e75363eecc1c2f2ebff541baa9607a3a09eda587bc">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>