### PR TITLE
Set 'clusterIP' to 'None' in the case of headless service.

### DIFF
--- a/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
+++ b/src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs
@@ -237,6 +237,7 @@ public static class KubernetesDeploymentDataExtensions
                     Name = x.Name
                 }).ToList(),
                 Type = data.ServiceType,
+                ClusterIP = data.HasPorts ? null : "None",
             },
         };
     }


### PR DESCRIPTION
### **User description**
Kubernetes only allows headless services (those with no ports) when `clusterIP` is set to `None`. This can be seen in `pkg/apis/core/validation/validation.go` of the Kubernetes implementation:

```go
func isHeadlessService(service *core.Service) bool {
	return service != nil &&
		len(service.Spec.ClusterIPs) == 1 &&
		service.Spec.ClusterIPs[0] == core.ClusterIPNone
}

[...]

func ValidateService(service *core.Service) field.ErrorList {
    [...]
	if len(service.Spec.Ports) == 0 && !isHeadlessService(service) && service.Spec.Type != core.ServiceTypeExternalName {
		allErrs = append(allErrs, field.Required(specPath.Child("ports"), ""))
	}
    [...]
}
```

In the case of headless services belonging to Aspire projects, this case is not satisfied in the generated service manifest:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations: {}
  labels:
    app: headless
  name: headless
spec:
  ports: []
  selector:
    app: headless
  type: ClusterIP
```

Attempting to install such a service via Helm results in failure due to the validation implementation shared above:

```
PS C:\source\AspireTest\AspireApp1\AspireApp1.AppHost\aspirate-output> helm install headless ./Chart
Error: INSTALLATION FAILED: 1 error occurred:
        * Service "headless" is invalid: spec.ports: Required value
```

This fix makes a minor change to the `V1Service` generation behaviors, implicitly setting `V1Service.Spec.ClusterIP` to `None` when `KubernetesDeploymentData.HasPorts` is `false`. As a result, manifests for headless services are generated as expected:

```yaml
apiVersion: v1
kind: Service
metadata:
  annotations: {}
  labels:
    app: headless
  name: headless
spec:
  clusterIP: None
  ports: []
  selector:
    app: headless
  type: ClusterIP
```

```
PS C:\source\AspireTest\AspireApp1\AspireApp1.AppHost\aspirate-output> helm install headless ./Chart
NAME: headless
LAST DEPLOYED: Sat Feb 22 18:23:24 2025
NAMESPACE: default
STATUS: deployed
REVISION: 1
TEST SUITE: None
```


___

### **PR Type**
Bug fix


___

### **Description**
- Set `ClusterIP` to `None` for headless services without ports.

- Fix Helm installation failure for headless services.

- Ensure generated Kubernetes manifests comply with validation rules.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KubernetesDeploymentDataExtensions.cs</strong><dd><code>Set `ClusterIP` to `None` for headless services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

src/Aspirate.Shared/Extensions/KubernetesDeploymentDataExtensions.cs

<li>Added logic to set <code>ClusterIP</code> to <code>None</code> for headless services.<br> <li> Ensured compliance with Kubernetes validation for services without <br>ports.


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/298/files#diff-87900570208fa13e565b0d969330dcbe921f92c29fa2a55bd7ea67d602032686">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>