### PR TITLE
Resource warning/error improvements

### DIFF
--- a/src/Aspirate.Commands/Actions/ActionExecutor.cs
+++ b/src/Aspirate.Commands/Actions/ActionExecutor.cs
@@ -74,6 +74,12 @@ public class ActionExecutor(IAnsiConsole console, IServiceProvider serviceProvid
             }
             catch (ActionCausesExitException exitException)
             {
+                // If we have an exception message, print it.
+                if (exitException.Message != null)
+                {
+                    console.MarkupLine($"[red bold]Error executing action [blue]'{executionAction.ActionKey}'[/]: {exitException.Message}[/]");
+                }
+
                 // Do nothing - the action is planned, and will skip the rest of the queue, returning the exit code.
                 console.MarkupLine($"[red bold]({exitException.ExitCode}): Aspirate will now exit.[/]");
                 return exitException.ExitCode;

--- a/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
+++ b/src/Aspirate.Services/Implementations/ManifestFileParserService.cs
@@ -40,7 +40,7 @@ public class ManifestFileParserService(
 
             if (type == null)
             {
-                console.MarkupLine($"[yellow]Resource {resourceName} does not have a type. Skipping as UnsupportedResource.[/]");
+                console.MarkupLine($"[yellow]Resource '{resourceName}' does not have a type. Skipping as UnsupportedResource.[/]");
                 resources.Add(resourceName, new UnsupportedResource());
                 continue;
             }
@@ -48,9 +48,19 @@ public class ManifestFileParserService(
             var rawBytes = Encoding.UTF8.GetBytes(resourceElement.GetRawText());
             var reader = new Utf8JsonReader(rawBytes);
 
-            var resource = serviceProvider.GetKeyedService<IResourceProcessor>(type) is { } handler
-                ? handler.Deserialize(ref reader)
-                : new UnsupportedResource();
+            var resourceProcessor = serviceProvider.GetKeyedService<IResourceProcessor>(type);
+
+            Resource resource;
+
+            if (resourceProcessor != null)
+            {
+                resource = resourceProcessor.Deserialize(ref reader);
+            }
+            else
+            {
+                console.MarkupLine($"[yellow]Resource '{resourceName}' is unsupported type '{type}'. Skipping as UnsupportedResource.[/]");
+                resource = new UnsupportedResource();
+            }
 
             if (resource != null)
             {

--- a/src/Aspirate.Shared/Exceptions/ActionCausesExitException.cs
+++ b/src/Aspirate.Shared/Exceptions/ActionCausesExitException.cs
@@ -1,8 +1,9 @@
 namespace Aspirate.Shared.Exceptions;
 
-public class ActionCausesExitException(int exitCode) : Exception
+public class ActionCausesExitException(int exitCode, string? message = null) : Exception(message)
 {
     public int ExitCode { get; } = exitCode;
 
-    public static void ExitNow(int exitCode = 1) => throw new ActionCausesExitException(exitCode);
+    [DoesNotReturn]
+    public static void ExitNow(int exitCode = 1, string? message = null) => throw new ActionCausesExitException(exitCode);
 }


### PR DESCRIPTION
Resource related issues have resulted in confusion on at least two occasions (#300 and #262). This PR adds warnings when unsupported resources are encountered, as well as improved error messages when binding references cannot be resolved (which is often due to unsupported resources).