### PR TITLE
project.v1 support

### DIFF
--- a/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/BuildAndPushContainersFromProjectsAction.cs
@@ -20,12 +20,12 @@ public sealed class BuildAndPushContainersFromProjectsAction(
             return true;
         }
 
-        var projectProcessor = Services.GetRequiredKeyedService<IResourceProcessor>(AspireComponentLiterals.Project) as ProjectProcessor;
-
         Logger.MarkupLine("[bold]Building all project resources, and pushing containers[/]");
 
         foreach (var resource in CurrentState.SelectedProjectComponents)
         {
+            var projectProcessor = Services.GetRequiredKeyedService<IResourceProcessor>(resource.Value.Type) as BaseProjectProcessor;
+
             await projectProcessor.BuildAndPushProjectContainer(resource, new()
             {
                 ContainerBuilder = CurrentState.ContainerBuilder.ToLower(),

--- a/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
+++ b/src/Aspirate.Commands/Actions/Containers/PopulateContainerDetailsForProjectsAction.cs
@@ -24,12 +24,12 @@ public sealed class PopulateContainerDetailsForProjectsAction(
 
     private async Task HandleProjects()
     {
-        var projectProcessor = Services.GetRequiredKeyedService<IResourceProcessor>(AspireComponentLiterals.Project) as ProjectProcessor;
-
         Logger.MarkupLine("[bold]Gathering container details for each project in selected components[/]");
 
         foreach (var resource in CurrentState.SelectedProjectComponents)
         {
+            var projectProcessor = Services.GetRequiredKeyedService<IResourceProcessor>(resource.Value.Type) as BaseProjectProcessor;
+
             await projectProcessor.PopulateContainerDetailsCacheForProject(resource, new()
             {
                 Registry = CurrentState.ContainerRegistry,

--- a/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/BaseContainerProcessor.cs
@@ -4,7 +4,7 @@ namespace Aspirate.Processors.Resources.AbstractProcessors;
 /// <summary>
 /// A base container component shared between Aspire version 0 and 1.
 /// </summary>
-public abstract class ContainerProcessorBase<TContainerResource>(
+public abstract class BaseContainerProcessor<TContainerResource>(
     IFileSystem fileSystem,
     IAnsiConsole console,
     ISecretProvider secretProvider,

--- a/src/Aspirate.Processors/Resources/AbstractProcessors/ContainerProcessor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/ContainerProcessor.cs
@@ -10,7 +10,7 @@ public class ContainerProcessor(
     IContainerCompositionService containerCompositionService,
     IContainerDetailsService containerDetailsService,
     IManifestWriter manifestWriter)
-        : ContainerProcessorBase<ContainerResource>(
+        : BaseContainerProcessor<ContainerResource>(
             fileSystem,
             console,
             secretProvider,

--- a/src/Aspirate.Processors/Resources/AbstractProcessors/ContainerV1Processor.cs
+++ b/src/Aspirate.Processors/Resources/AbstractProcessors/ContainerV1Processor.cs
@@ -10,7 +10,7 @@ public class ContainerV1Processor(
     IContainerCompositionService containerCompositionService,
     IContainerDetailsService containerDetailsService,
     IManifestWriter manifestWriter)
-        : ContainerProcessorBase<ContainerV1Resource>(
+        : BaseContainerProcessor<ContainerV1Resource>(
             fileSystem,
             console,
             secretProvider,

--- a/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
+++ b/src/Aspirate.Processors/Resources/Project/BaseProjectProcessor.cs
@@ -1,0 +1,155 @@
+﻿namespace Aspirate.Processors.Resources.Project;
+
+/// <summary>
+/// A base project component shared between versions 0 and 1 of Aspire.
+/// </summary>
+public abstract class BaseProjectProcessor(
+    IFileSystem fileSystem,
+    IAnsiConsole console,
+    ISecretProvider secretProvider,
+    IContainerCompositionService containerCompositionService,
+    IContainerDetailsService containerDetailsService,
+    IManifestWriter manifestWriter)
+    : BaseResourceProcessor(fileSystem, console, manifestWriter)
+{
+    private readonly IReadOnlyCollection<string> _manifests =
+    [
+        $"{TemplateLiterals.DeploymentType}.yaml",
+        $"{TemplateLiterals.ServiceType}.yaml",
+    ];
+
+    private readonly Dictionary<string, MsBuildContainerProperties> _containerDetailsCache = [];
+
+    /// <inheritdoc />
+    public override Resource? Deserialize(ref Utf8JsonReader reader) =>
+        JsonSerializer.Deserialize<ProjectResource>(ref reader);
+
+    public override Task<bool> CreateManifests(CreateManifestsOptions options)
+    {
+        var resourceOutputPath = Path.Combine(options.OutputPath, options.Resource.Key);
+
+        _manifestWriter.EnsureOutputDirectoryExistsAndIsClean(resourceOutputPath);
+
+        if (!_containerDetailsCache.TryGetValue(options.Resource.Key, out var containerDetails))
+        {
+            throw new InvalidOperationException($"Container details for project {options.Resource.Key} not found.");
+        }
+
+        var project = options.Resource.Value as ProjectResource;
+
+        var data = PopulateKubernetesDeploymentData(options, containerDetails, project);
+
+        _manifestWriter.CreateDeployment(resourceOutputPath, data, options.TemplatePath);
+        _manifestWriter.CreateService(resourceOutputPath, data, options.TemplatePath);
+        _manifestWriter.CreateComponentKustomizeManifest(resourceOutputPath, data, options.TemplatePath);
+
+        LogCompletion(resourceOutputPath);
+
+        return Task.FromResult(true);
+    }
+
+    private KubernetesDeploymentData PopulateKubernetesDeploymentData(BaseKubernetesCreateOptions options, MsBuildContainerProperties containerDetails, ProjectResource? project) =>
+        new KubernetesDeploymentData()
+            .SetWithDashboard(options.WithDashboard.GetValueOrDefault())
+            .SetName(options.Resource.Key)
+            .SetContainerImage(containerDetails.FullContainerImage)
+            .SetImagePullPolicy(options.ImagePullPolicy)
+            .SetEnv(GetFilteredEnvironmentalVariables(options.Resource, options.DisableSecrets, options.WithDashboard))
+            .SetAnnotations(project.Annotations)
+            .SetArgs(project.Args)
+            .SetSecrets(GetSecretEnvironmentalVariables(options.Resource, options.DisableSecrets, options.WithDashboard))
+            .SetSecretsFromSecretState(options.Resource, secretProvider, options.DisableSecrets)
+            .SetIsProject(true)
+            .SetPorts(options.Resource.MapBindingsToPorts())
+            .SetManifests(_manifests)
+            .SetWithPrivateRegistry(options.WithPrivateRegistry.GetValueOrDefault())
+            .Validate();
+
+    public async Task BuildAndPushProjectContainer(KeyValuePair<string, Resource> resource, ContainerOptions options, bool nonInteractive, string? runtimeIdentifier, bool preferDockerfile)
+    {
+        var project = resource.Value as ProjectResource;
+
+        if (!_containerDetailsCache.TryGetValue(resource.Key, out var containerDetails))
+        {
+            throw new InvalidOperationException($"Container details for project {resource.Key} not found.");
+        }
+
+        var dockerfileFile = !string.IsNullOrEmpty(containerDetails.DockerfileFile) ? containerDetails.DockerfileFile : Path.Combine(Path.GetDirectoryName(project.Path), "Dockerfile");
+
+        if (preferDockerfile && File.Exists(dockerfileFile))
+        {
+            _console.MarkupLine($"[bold yellow]Using custom Dockerfile to build project {resource.Key}.[/]");
+
+            var dockerfileResource = new DockerfileResource()
+            {
+                Path = dockerfileFile,
+                Name = !string.IsNullOrEmpty(containerDetails.ContainerRepository) ? containerDetails.ContainerRepository : project.Name,
+                Context = !string.IsNullOrEmpty(containerDetails.DockerfileContext) ? containerDetails.DockerfileContext : options.BuildContext,
+                Annotations = project.Annotations,
+                Bindings = project.Bindings,
+                Env = project.Env,
+                BuildArgs = options.BuildArgs
+            };
+
+            await containerCompositionService.BuildAndPushContainerForDockerfile(dockerfileResource, options, nonInteractive);
+        }
+        else
+        {
+            await containerCompositionService.BuildAndPushContainerForProject(project, containerDetails, options, nonInteractive, runtimeIdentifier);
+        }
+
+        _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Building and Pushing container for project [blue]{resource.Key}[/]");
+    }
+
+    public async Task PopulateContainerDetailsCacheForProject(KeyValuePair<string, Resource> resource, ContainerOptions options)
+    {
+        var project = resource.Value as ProjectResource;
+
+        var details = await containerDetailsService.GetContainerDetails(resource.Key, project, options);
+
+        var success = _containerDetailsCache.TryAdd(resource.Key, details);
+
+        if (!success)
+        {
+            throw new InvalidOperationException($"Failed to add container details for project {resource.Key} to cache.");
+        }
+
+        _console.MarkupLine($"[green]({EmojiLiterals.CheckMark}) Done: [/] Populated container details cache for project [blue]{resource.Key}[/]");
+    }
+
+    public override ComposeService CreateComposeEntry(CreateComposeEntryOptions options)
+    {
+        var response = new ComposeService();
+
+        if (!_containerDetailsCache.TryGetValue(options.Resource.Key, out var containerDetails))
+        {
+            throw new InvalidOperationException($"Container details for project {options.Resource.Key} not found.");
+        }
+
+        response.Service = Builder.MakeService(options.Resource.Key)
+            .WithEnvironment(options.Resource.MapResourceToEnvVars(options.WithDashboard))
+            .WithContainerName(options.Resource.Key)
+            .WithRestartPolicy(ERestartMode.UnlessStopped)
+            .WithPortMappings(options.Resource.MapBindingsToPorts().MapPortsToDockerComposePorts())
+            .WithImage(containerDetails.FullContainerImage.ToLowerInvariant())
+            .Build();
+
+        response.IsProject = true;
+
+        return response;
+    }
+
+    public override List<object> CreateKubernetesObjects(CreateKubernetesObjectsOptions options)
+    {
+        var project = options.Resource.Value as ProjectResource;
+
+        if (!_containerDetailsCache.TryGetValue(options.Resource.Key, out var containerDetails))
+        {
+            throw new InvalidOperationException($"Container details for project {options.Resource.Key} not found.");
+        }
+
+        var data = PopulateKubernetesDeploymentData(options, containerDetails, project);
+
+        return data.ToKubernetesObjects(options.EncodeSecrets);
+    }
+}

--- a/src/Aspirate.Processors/Resources/Project/ProjectV1Processor.cs
+++ b/src/Aspirate.Processors/Resources/Project/ProjectV1Processor.cs
@@ -1,9 +1,9 @@
-namespace Aspirate.Processors.Resources.Project;
+﻿namespace Aspirate.Processors.Resources.Project;
 
 /// <summary>
-/// A project component for version 0 of Aspire.
+/// A project component for version 1 of Aspire.
 /// </summary>
-public sealed class ProjectProcessor(
+public sealed class ProjectV1Processor(
     IFileSystem fileSystem,
     IAnsiConsole console,
     ISecretProvider secretProvider,
@@ -19,5 +19,5 @@ public sealed class ProjectProcessor(
         manifestWriter)
 {
     /// <inheritdoc />
-    public override string ResourceType => AspireComponentLiterals.Project;
+    public override string ResourceType => AspireComponentLiterals.ProjectV1;
 }

--- a/src/Aspirate.Processors/ServiceCollectionExtensions.cs
+++ b/src/Aspirate.Processors/ServiceCollectionExtensions.cs
@@ -14,6 +14,7 @@ public static class ServiceCollectionExtensions
     public static IServiceCollection AddAspirateProcessors(this IServiceCollection services) =>
         services
             .RegisterProcessor<ProjectProcessor>(AspireComponentLiterals.Project)
+            .RegisterProcessor<ProjectV1Processor>(AspireComponentLiterals.ProjectV1)
             .RegisterProcessor<DockerfileProcessor>(AspireComponentLiterals.Dockerfile)
             .RegisterProcessor<ContainerProcessor>(AspireComponentLiterals.Container)
             .RegisterProcessor<ContainerV1Processor>(AspireComponentLiterals.ContainerV1)

--- a/src/Aspirate.Services/GlobalUsings.cs
+++ b/src/Aspirate.Services/GlobalUsings.cs
@@ -20,6 +20,7 @@ global using Aspirate.Shared.Models;
 global using Aspirate.Shared.Models.Aspirate;
 global using Aspirate.Shared.Models.AspireManifests;
 global using Aspirate.Shared.Models.AspireManifests.Components;
+global using Aspirate.Shared.Models.AspireManifests.Components.Common;
 global using Aspirate.Shared.Models.AspireManifests.Components.V0;
 global using Aspirate.Shared.Models.AspireManifests.Components.V1.Container;
 global using Aspirate.Shared.Models.AspireManifests.Interfaces;

--- a/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
+++ b/src/Aspirate.Services/Implementations/ContainerDetailsService.cs
@@ -1,4 +1,5 @@
 namespace Aspirate.Services.Implementations;
+
 public class ContainerDetailsService(IProjectPropertyService propertyService, IAnsiConsole console) : IContainerDetailsService
 {
     private static readonly StringBuilder _imageBuilder = new();

--- a/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
+++ b/src/Aspirate.Shared/Literals/AspireComponentLiterals.cs
@@ -4,6 +4,7 @@ namespace Aspirate.Shared.Literals;
 public static class AspireComponentLiterals
 {
     public const string Project = "project.v0";
+    public const string ProjectV1 = "project.v1";
 
     public const string Dockerfile = "dockerfile.v0";
 

--- a/src/Aspirate.Shared/Models/AspireManifests/Components/Common/ProjectResource.cs
+++ b/src/Aspirate.Shared/Models/AspireManifests/Components/Common/ProjectResource.cs
@@ -1,4 +1,4 @@
-namespace Aspirate.Shared.Models.AspireManifests.Components.V0;
+namespace Aspirate.Shared.Models.AspireManifests.Components.Common;
 
 /// <summary>
 /// A project within an aspire manifest.


### PR DESCRIPTION
This PR adds support for the `project.v1` resource type. As described in #312, the use of methods such as `AddAzureContainerAppsInfrastructure` and `PublishAsAzureContainerApp` results in project resources appearing in the manifest as `project.v1` rather than `project.v0`. As per the manifest schema, the only current difference between the two is the presence of an Azure Bicep `deployment` property in v1. While this functionality cannot be supported, there may be scenarios where users still want to deploy to other targets despite the presence of Azure-specific configurations (also #312).

In alignment with the versioning strategy used to share functionality between `container.v0` and `container.v1`, core project processing functionality was moved to `BaseProjectProcessor`, from which `ProjectProcessor` and `ProjectV1Processor` are derived. While there is currently little divergence, this may be beneficial in the event of future iteration on the project resource type.

This PR also renames `ContainerProcessorBase` to `BaseContainerProcessor` to bring it inline with the naming conventions of the project.