### PR TITLE
Fix null deref issue in apply command

### DIFF
--- a/src/Aspirate.Services/Implementations/KustomizeService.cs
+++ b/src/Aspirate.Services/Implementations/KustomizeService.cs
@@ -54,7 +54,10 @@ public class KustomizeService(IFileSystem fileSystem, IShellExecutionService she
 
         foreach (var resourceSecrets in secretProvider.State.Secrets.Where(x => x.Value.Keys.Count > 0))
         {
-            var resourcePath = fileSystem.Path.Combine(state.OutputPath, resourceSecrets.Key);
+            var manifestPath = (state.OutputPath ?? state.InputPath) ??
+                throw new InvalidOperationException("Could not write secret, manifest path not set.");
+
+            var resourcePath = fileSystem.Path.Combine(manifestPath, resourceSecrets.Key);
 
             if (!fileSystem.Directory.Exists(resourcePath))
             {


### PR DESCRIPTION
### **User description**
This PR covers #231. In cases where `WriteSecretsOutToTempFiles` is called, `AspirateState.OutputPath` is only set when read from state. In the event of ignoring previous state, this causes a `NullReferenceException`. This fix updates `WriteSecretsOutToTempFiles` to fall back to `AspirateState.InputPath` in such cases.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes null dereference in `apply` command when previous state is ignored

- Ensures fallback to `InputPath` if `OutputPath` is null during secret writing

- Improves error handling for missing manifest path


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>KustomizeService.cs</strong><dd><code>Add fallback for manifest path to prevent null dereference</code></dd></summary>
<hr>

src/Aspirate.Services/Implementations/KustomizeService.cs

<li>Adds fallback to <code>InputPath</code> if <code>OutputPath</code> is null when writing secrets<br> <li> Throws explicit error if neither path is set, improving error <br>messaging<br> <li> Prevents null reference exception during manifest application


</details>


  </td>
  <td><a href="https://github.com/prom3theu5/aspirational-manifests/pull/324/files#diff-76e6d5431a86c4f0d008303950bbe53004e23241faf3f17ae2f5281332743d0b">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>